### PR TITLE
refactor: Implement granular updates for article title and content

### DIFF
--- a/cmd/article-manager/main.go
+++ b/cmd/article-manager/main.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	// "time" // Removed: Für eventuelle Timeouts oder Logging
+
+	"article-manager/internal/commands"
+	"article-manager/internal/eventstore"
+	"article-manager/internal/handlers"
+	// "article-manager/internal/readmodels" // Removed: Wird für Antworttypen benötigt in main, nur in Tests
+
+	"github.com/google/uuid"
+)
+
+// App bündelt die Handler und Abhängigkeiten der Anwendung.
+type App struct {
+	commandHandler *handlers.ArticleCommandHandler
+	eventHandler   *handlers.ArticleEventHandler
+	queryHandler   *handlers.ArticleQueryHandler
+	eventStore     eventstore.EventStore
+}
+
+// --- HTTP Handler Methoden für App ---
+
+// handleCreateArticle verarbeitet Anfragen zum Erstellen neuer Artikel.
+// POST /articles
+func (a *App) handleCreateArticle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Nur POST-Methode erlaubt", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		Title   string `json:"title"`
+		Content string `json:"content"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Fehler beim Parsen des JSON-Requests: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if req.Title == "" || req.Content == "" {
+		http.Error(w, "Titel und Inhalt dürfen nicht leer sein", http.StatusBadRequest)
+		return
+	}
+
+	articleID := uuid.New().String()
+	cmd := commands.CreateArticleCommand{
+		ID:      articleID,
+		Title:   req.Title,
+		Content: req.Content,
+	}
+
+	if err := a.commandHandler.HandleCreateArticle(cmd); err != nil {
+		log.Printf("Fehler bei HandleCreateArticle Command: %v", err)
+		http.Error(w, "Fehler beim Erstellen des Artikels: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	articleReadModel, err := a.queryHandler.GetArticleByID(articleID)
+	if err != nil {
+		log.Printf("Fehler beim Abrufen des ReadModels nach Create: %v", err)
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{"id": articleID, "status": "Artikel erstellt, ReadModel wird aktualisiert"})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(articleReadModel); err != nil {
+		log.Printf("Fehler beim Senden der JSON-Antwort für CreateArticle: %v", err)
+	}
+}
+
+// handleGetAllArticles verarbeitet Anfragen zum Abrufen aller Artikel.
+// GET /articles
+func (a *App) handleGetAllArticles(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Nur GET-Methode erlaubt", http.StatusMethodNotAllowed)
+		return
+	}
+
+	articles, err := a.queryHandler.GetAllArticles()
+	if err != nil {
+		log.Printf("Fehler bei GetAllArticles Query: %v", err)
+		http.Error(w, "Fehler beim Abrufen aller Artikel: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(articles); err != nil {
+		log.Printf("Fehler beim Senden der JSON-Antwort für GetAllArticles: %v", err)
+	}
+}
+
+// handleGetArticleByID verarbeitet Anfragen zum Abrufen eines einzelnen Artikels.
+// GET /articles/{id}
+func (a *App) handleGetArticleByID(w http.ResponseWriter, r *http.Request, id string) {
+	// Methode wird im Dispatcher geprüft
+	article, err := a.queryHandler.GetArticleByID(id)
+	if err != nil {
+		log.Printf("Fehler bei GetArticleByID Query für ID %s: %v", id, err)
+		if strings.Contains(err.Error(), "nicht gefunden") {
+			http.Error(w, "Artikel nicht gefunden", http.StatusNotFound)
+		} else {
+			http.Error(w, "Fehler beim Abrufen des Artikels: "+err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(article); err != nil {
+		log.Printf("Fehler beim Senden der JSON-Antwort für GetArticleByID: %v", err)
+	}
+}
+
+// handleUpdateArticleTitle aktualisiert den Titel eines Artikels.
+// PUT/PATCH /articles/{id}/title
+// Request Body: {"title": "neuer Titel"}
+func (a *App) handleUpdateArticleTitle(w http.ResponseWriter, r *http.Request, id string) {
+	// Methode (PUT/PATCH) wird im Dispatcher geprüft
+	var req struct {
+		Title string `json:"title"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Fehler beim Parsen des JSON-Requests: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Title == "" {
+		http.Error(w, "Titel darf nicht leer sein", http.StatusBadRequest)
+		return
+	}
+
+	cmd := commands.UpdateArticleTitleCommand{ID: id, Title: req.Title}
+	if err := a.commandHandler.HandleUpdateArticleTitle(cmd); err != nil {
+		log.Printf("Fehler bei HandleUpdateArticleTitle Command für ID %s: %v", id, err)
+		if strings.Contains(err.Error(), "nicht gefunden") {
+			http.Error(w, "Fehler beim Aktualisieren des Titels: Artikel nicht gefunden", http.StatusNotFound)
+		} else if strings.Contains(err.Error(), "Titel ist identisch") {
+			http.Error(w, "Fehler beim Aktualisieren des Titels: "+err.Error(), http.StatusBadRequest)
+		} else if strings.Contains(err.Error(), "optimistic lock error") {
+			http.Error(w, "Fehler beim Aktualisieren des Titels: Konflikt (Optimistic Lock)", http.StatusConflict)
+		} else {
+			http.Error(w, "Fehler beim Aktualisieren des Titels: "+err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	articleReadModel, err := a.queryHandler.GetArticleByID(id)
+	if err != nil {
+		log.Printf("Fehler beim Abrufen des ReadModels nach UpdateTitle für ID %s: %v", id, err)
+		http.Error(w, "Titel aktualisiert, aber Fehler beim Abrufen des ReadModels: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(articleReadModel)
+}
+
+// handleUpdateArticleContent aktualisiert den Inhalt eines Artikels.
+// PUT/PATCH /articles/{id}/content
+// Request Body: {"content": "neuer Inhalt"}
+func (a *App) handleUpdateArticleContent(w http.ResponseWriter, r *http.Request, id string) {
+	// Methode (PUT/PATCH) wird im Dispatcher geprüft
+	var req struct {
+		Content string `json:"content"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Fehler beim Parsen des JSON-Requests: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Content == "" {
+		http.Error(w, "Inhalt darf nicht leer sein", http.StatusBadRequest)
+		return
+	}
+
+	cmd := commands.UpdateArticleContentCommand{ID: id, Content: req.Content}
+	if err := a.commandHandler.HandleUpdateArticleContent(cmd); err != nil {
+		log.Printf("Fehler bei HandleUpdateArticleContent Command für ID %s: %v", id, err)
+		if strings.Contains(err.Error(), "nicht gefunden") {
+			http.Error(w, "Fehler beim Aktualisieren des Inhalts: Artikel nicht gefunden", http.StatusNotFound)
+		} else if strings.Contains(err.Error(), "Inhalt ist identisch") {
+			http.Error(w, "Fehler beim Aktualisieren des Inhalts: "+err.Error(), http.StatusBadRequest)
+		} else if strings.Contains(err.Error(), "optimistic lock error") {
+			http.Error(w, "Fehler beim Aktualisieren des Inhalts: Konflikt (Optimistic Lock)", http.StatusConflict)
+		} else {
+			http.Error(w, "Fehler beim Aktualisieren des Inhalts: "+err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	articleReadModel, err := a.queryHandler.GetArticleByID(id)
+	if err != nil {
+		log.Printf("Fehler beim Abrufen des ReadModels nach UpdateContent für ID %s: %v", id, err)
+		http.Error(w, "Inhalt aktualisiert, aber Fehler beim Abrufen des ReadModels: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(articleReadModel)
+}
+
+// handleDeleteArticle verarbeitet Anfragen zum Löschen von Artikeln.
+// DELETE /articles/{id}
+func (a *App) handleDeleteArticle(w http.ResponseWriter, r *http.Request, id string) {
+	// Methode wird im Dispatcher geprüft
+	cmd := commands.DeleteArticleCommand{ID: id}
+	if err := a.commandHandler.HandleDeleteArticle(cmd); err != nil {
+		log.Printf("Fehler bei HandleDeleteArticle Command für ID %s: %v", id, err)
+		if strings.Contains(err.Error(), "nicht gefunden") {
+			http.Error(w, "Fehler beim Löschen: Artikel nicht gefunden", http.StatusNotFound)
+		} else if strings.Contains(err.Error(), "optimistic lock error") {
+			http.Error(w, "Fehler beim Löschen: Konflikt (Optimistic Lock)", http.StatusConflict)
+		} else {
+			http.Error(w, "Fehler beim Löschen des Artikels: "+err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// routeArticleDetailRequests leitet Anfragen für /articles/{id} und /articles/{id}/resource weiter.
+func (a *App) routeArticleDetailRequests(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/articles/")
+	parts := strings.SplitN(path, "/", 2) // Split into max 2 parts: ID and optional sub-resource
+	id := parts[0]
+
+	if id == "" {
+		http.NotFound(w, r) // Should not happen if registered for /articles/
+		return
+	}
+
+	if len(parts) == 1 { // Path ist /articles/{id}
+		switch r.Method {
+		case http.MethodGet:
+			a.handleGetArticleByID(w, r, id)
+		case http.MethodDelete:
+			a.handleDeleteArticle(w, r, id)
+		default:
+			http.Error(w, "Methode nicht erlaubt für /articles/{id}", http.StatusMethodNotAllowed)
+		}
+	} else if len(parts) == 2 { // Path ist /articles/{id}/resource
+		resource := parts[1]
+		if resource == "title" && (r.Method == http.MethodPut || r.Method == http.MethodPatch) {
+			a.handleUpdateArticleTitle(w, r, id)
+		} else if resource == "content" && (r.Method == http.MethodPut || r.Method == http.MethodPatch) {
+			a.handleUpdateArticleContent(w, r, id)
+		} else {
+			http.NotFound(w, r)
+		}
+	} else {
+		http.NotFound(w, r) // Sollte durch SplitN(..., 2) nicht vorkommen
+	}
+}
+
+func main() {
+	eventStore := eventstore.NewInMemoryEventStore()
+	eventHandler := handlers.NewArticleEventHandler()
+	commandHandler := handlers.NewArticleCommandHandler(eventStore, eventHandler)
+	queryHandler := handlers.NewArticleQueryHandler(eventHandler)
+
+	app := &App{
+		commandHandler: commandHandler,
+		eventHandler:   eventHandler,
+		queryHandler:   queryHandler,
+		eventStore:     eventStore,
+	}
+
+	mux := http.NewServeMux()
+
+	// Handler für /articles (ohne ID)
+	mux.HandleFunc("/articles", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			app.handleCreateArticle(w, r)
+		case http.MethodGet:
+			app.handleGetAllArticles(w, r)
+		default:
+			http.Error(w, "Methode nicht erlaubt für /articles", http.StatusMethodNotAllowed)
+		}
+	})
+
+	// Handler für /articles/{id}... Routen
+	mux.HandleFunc("/articles/", app.routeArticleDetailRequests)
+
+	log.Println("Starte Article-Manager-Server auf Port 8080...")
+	if err := http.ListenAndServe(":8080", mux); err != nil {
+		log.Fatalf("Fehler beim Starten des HTTP-Servers: %v", err)
+	}
+}

--- a/cmd/article-manager/main_test.go
+++ b/cmd/article-manager/main_test.go
@@ -1,0 +1,509 @@
+package main
+
+import (
+	"article-manager/internal/article" // For direct aggregate manipulation in test setup
+	"article-manager/internal/commands"
+	"article-manager/internal/eventstore"
+	"article-manager/internal/handlers"
+	"article-manager/internal/readmodels"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// Helper to initialize the App for tests
+func setupTestApp() *App {
+	es := eventstore.NewInMemoryEventStore()
+	eh := handlers.NewArticleEventHandler()
+	// Ensure NewArticleCommandHandler accepts the EventHandler interface
+	ch := handlers.NewArticleCommandHandler(es, eh) 
+	qh := handlers.NewArticleQueryHandler(eh)
+
+	return &App{
+		commandHandler: ch,
+		eventHandler:   eh,
+		queryHandler:   qh,
+		eventStore:     es,
+	}
+}
+
+// Helper to setup the main router for testing, reflecting main.go
+func setupTestRouter(app *App) *http.ServeMux {
+	mux := http.NewServeMux()
+	
+	// Handler for /articles (POST create, GET all)
+	mux.HandleFunc("/articles", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			app.handleCreateArticle(w, r)
+		case http.MethodGet:
+			app.handleGetAllArticles(w, r)
+		default:
+			http.Error(w, "Methode nicht erlaubt für /articles", http.StatusMethodNotAllowed)
+		}
+	})
+
+	// Handler for /articles/{id}... routes, dispatched by routeArticleDetailRequests
+	mux.HandleFunc("/articles/", app.routeArticleDetailRequests)
+	return mux
+}
+
+// Helper to create an article directly for test setup
+func createArticleForTest(t *testing.T, app *App, title, content string) readmodels.ArticleReadModel {
+	t.Helper()
+	articleID := uuid.New().String()
+	createCmd := commands.CreateArticleCommand{ID: articleID, Title: title, Content: content}
+	
+	agg := article.NewArticleAggregate(createCmd.ID)
+	if err := agg.HandleCreateArticleCommand(createCmd.ID, createCmd.Title, createCmd.Content); err != nil {
+		t.Fatalf("Failed to handle create command for test setup: %v", err)
+	}
+	
+	if err := app.eventStore.SaveEvents(agg.ID, agg.GetChanges(), -1); err != nil {
+		t.Fatalf("Failed to save events for test setup: %v", err)
+	}
+	
+	for _, event := range agg.GetChanges() {
+		if err := app.eventHandler.HandleEvent(event); err != nil {
+			t.Fatalf("Failed to handle event for test setup: %v", err)
+		}
+	}
+	agg.ClearChanges()
+
+	rm, err := app.queryHandler.GetArticleByID(articleID)
+	if err != nil {
+		t.Fatalf("Failed to get created article for test setup: %v", err)
+	}
+	return rm
+}
+
+
+// --- Create Article Tests ---
+func TestHandleCreateArticle_Success(t *testing.T) {
+	app := setupTestApp()
+	router := setupTestRouter(app)
+
+	payload := map[string]string{"title": "Test API Title", "content": "Test API Content"}
+	jsonPayload, _ := json.Marshal(payload)
+
+	req, _ := http.NewRequest("POST", "/articles", bytes.NewBuffer(jsonPayload))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusCreated {
+		t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", status, http.StatusCreated, rr.Body.String())
+	}
+
+	var createdArticle readmodels.ArticleReadModel
+	if err := json.NewDecoder(rr.Body).Decode(&createdArticle); err != nil {
+		t.Fatalf("Could not decode response: %v. Body: %s", err, rr.Body.String())
+	}
+
+	if createdArticle.Title != payload["title"] {
+		t.Errorf("handler returned unexpected title: got '%s' want '%s'", createdArticle.Title, payload["title"])
+	}
+	if createdArticle.Content != payload["content"] {
+		t.Errorf("handler returned unexpected content: got '%s' want '%s'", createdArticle.Content, payload["content"])
+	}
+	if createdArticle.ID == "" {
+		t.Error("handler returned empty ID")
+	}
+	if createdArticle.Version != 0 {
+		t.Errorf("handler returned unexpected version: got %d want %d", createdArticle.Version, 0)
+	}
+}
+
+func TestHandleCreateArticle_BadRequest_InvalidJSON(t *testing.T) {
+	app := setupTestApp()
+	router := setupTestRouter(app)
+
+	req, _ := http.NewRequest("POST", "/articles", bytes.NewBufferString("{invalid json"))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code for invalid JSON: got %v want %v", status, http.StatusBadRequest)
+	}
+}
+
+func TestHandleCreateArticle_BadRequest_MissingFields(t *testing.T) {
+	app := setupTestApp()
+	router := setupTestRouter(app)
+
+	testCases := []struct {
+		name    string
+		payload map[string]string
+	}{
+		{"MissingTitle", map[string]string{"content": "Some Content"}},
+		{"MissingContent", map[string]string{"title": "Some Title"}},
+		{"EmptyTitle", map[string]string{"title": "", "content": "Some Content"}},
+		{"EmptyContent", map[string]string{"title": "Some Title", "content": ""}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			jsonPayload, _ := json.Marshal(tc.payload)
+			req, _ := http.NewRequest("POST", "/articles", bytes.NewBuffer(jsonPayload))
+			req.Header.Set("Content-Type", "application/json")
+
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+
+			if status := rr.Code; status != http.StatusBadRequest {
+				t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", status, http.StatusBadRequest, rr.Body.String())
+			}
+		})
+	}
+}
+
+// --- Get Article By ID Tests ---
+func TestHandleGetArticleByID_Success(t *testing.T) {
+	app := setupTestApp()
+	router := setupTestRouter(app)
+	createdArticle := createArticleForTest(t, app, "Title Get", "Content Get")
+
+	req, _ := http.NewRequest("GET", "/articles/"+createdArticle.ID, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", status, http.StatusOK, rr.Body.String())
+	}
+
+	var fetchedArticle readmodels.ArticleReadModel
+	if err := json.NewDecoder(rr.Body).Decode(&fetchedArticle); err != nil {
+		t.Fatalf("Could not decode response: %v. Body: %s", err, rr.Body.String())
+	}
+	if fetchedArticle.ID != createdArticle.ID || fetchedArticle.Title != createdArticle.Title || fetchedArticle.Version != 0 {
+		t.Errorf("unexpected article data: got %+v want %+v", fetchedArticle, createdArticle)
+	}
+}
+
+func TestHandleGetArticleByID_NotFound(t *testing.T) {
+	app := setupTestApp()
+	router := setupTestRouter(app)
+
+	req, _ := http.NewRequest("GET", "/articles/non-existent-id", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusNotFound {
+		t.Errorf("handler returned wrong status code for not found: got %v want %v", status, http.StatusNotFound)
+	}
+}
+
+// --- Get All Articles Tests ---
+func TestHandleGetAllArticles_Success_Empty(t *testing.T) {
+	app := setupTestApp()
+	router := setupTestRouter(app)
+
+	req, _ := http.NewRequest("GET", "/articles", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", status, http.StatusOK, rr.Body.String())
+	}
+
+	var articles []readmodels.ArticleReadModel
+	if err := json.NewDecoder(rr.Body).Decode(&articles); err != nil {
+		t.Fatalf("Could not decode response: %v. Body: %s", err, rr.Body.String())
+	}
+	if len(articles) != 0 {
+		t.Errorf("expected 0 articles, got %d", len(articles))
+	}
+}
+
+func TestHandleGetAllArticles_Success_WithData(t *testing.T) {
+	app := setupTestApp()
+	router := setupTestRouter(app)
+
+	article1 := createArticleForTest(t, app, "Article 1", "Content 1")
+	article2 := createArticleForTest(t, app, "Article 2", "Content 2")
+
+	req, _ := http.NewRequest("GET", "/articles", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", status, http.StatusOK, rr.Body.String())
+	}
+
+	var articles []readmodels.ArticleReadModel
+	if err := json.NewDecoder(rr.Body).Decode(&articles); err != nil {
+		t.Fatalf("Could not decode response: %v. Body: %s", err, rr.Body.String())
+	}
+	if len(articles) != 2 {
+		t.Fatalf("expected 2 articles, got %d", len(articles))
+	}
+	
+	foundMap := make(map[string]bool)
+	for _, art := range articles {
+		foundMap[art.ID] = true
+	}
+	if !foundMap[article1.ID] || !foundMap[article2.ID] {
+		t.Errorf("expected both articles to be present. Found IDs: %v", foundMap)
+	}
+}
+
+// --- Update Article Title Tests ---
+func TestHandleUpdateArticleTitle(t *testing.T) {
+	app := setupTestApp()
+	router := setupTestRouter(app)
+	initialArticle := createArticleForTest(t, app, "Original Title", "Original Content")
+
+	t.Run("Success_PUT", func(t *testing.T) {
+		payload := map[string]string{"title": "Updated Title via PUT"}
+		jsonPayload, _ := json.Marshal(payload)
+		req, _ := http.NewRequest(http.MethodPut, "/articles/"+initialArticle.ID+"/title", bytes.NewBuffer(jsonPayload))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", status, http.StatusOK, rr.Body.String())
+		}
+		var respModel readmodels.ArticleReadModel
+		if err := json.NewDecoder(rr.Body).Decode(&respModel); err != nil {
+			t.Fatalf("Could not decode response: %v", err)
+		}
+		if respModel.Title != payload["title"] || respModel.Content != initialArticle.Content || respModel.Version != initialArticle.Version+1 {
+			t.Errorf("unexpected article state. Got: %+v", respModel)
+		}
+	})
+    
+	// Assuming the title was updated, version is now initialArticle.Version + 1
+    // Create a new article for PATCH to ensure clean state for versioning, or re-fetch.
+    // For simplicity, let's use a new article.
+    patchArticle := createArticleForTest(t, app, "Patch Original Title", "Patch Original Content")
+	t.Run("Success_PATCH", func(t *testing.T) {
+		payload := map[string]string{"title": "Updated Title via PATCH"}
+		jsonPayload, _ := json.Marshal(payload)
+		req, _ := http.NewRequest(http.MethodPatch, "/articles/"+patchArticle.ID+"/title", bytes.NewBuffer(jsonPayload))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", status, http.StatusOK, rr.Body.String())
+		}
+		var respModel readmodels.ArticleReadModel
+		if err := json.NewDecoder(rr.Body).Decode(&respModel); err != nil {
+			t.Fatalf("Could not decode response: %v", err)
+		}
+		if respModel.Title != payload["title"] || respModel.Content != patchArticle.Content || respModel.Version != patchArticle.Version+1 {
+			t.Errorf("unexpected article state. Got: %+v", respModel)
+		}
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		payload := map[string]string{"title": "Non Existent Title"}
+		jsonPayload, _ := json.Marshal(payload)
+		req, _ := http.NewRequest(http.MethodPut, "/articles/non-existent-id/title", bytes.NewBuffer(jsonPayload))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		if status := rr.Code; status != http.StatusNotFound {
+			t.Errorf("expected status %d, got %d", http.StatusNotFound, rr.Code)
+		}
+	})
+
+	badRequestTestCases := []struct{ name, payload, expectedErrorPart string }{
+		{"InvalidJSON", "{invalid", "Fehler beim Parsen"},
+		{"EmptyTitle", `{"title":""}`, "Titel darf nicht leer sein"},
+		{"MissingTitle", `{}`, "Titel darf nicht leer sein"}, // Assuming empty string if missing
+	}
+	for _, tc := range badRequestTestCases {
+		t.Run("BadRequest_"+tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodPut, "/articles/"+initialArticle.ID+"/title", bytes.NewBufferString(tc.payload))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+			if status := rr.Code; status != http.StatusBadRequest {
+				t.Errorf("expected status %d, got %d. Body: %s", http.StatusBadRequest, rr.Code, rr.Body.String())
+			}
+			if !strings.Contains(rr.Body.String(), tc.expectedErrorPart) {
+				t.Errorf("expected error message to contain '%s', got '%s'", tc.expectedErrorPart, rr.Body.String())
+			}
+		})
+	}
+}
+
+// --- Update Article Content Tests ---
+func TestHandleUpdateArticleContent(t *testing.T) {
+	app := setupTestApp()
+	router := setupTestRouter(app)
+	initialArticle := createArticleForTest(t, app, "Original Title", "Original Content")
+
+	t.Run("Success_PUT", func(t *testing.T) {
+		payload := map[string]string{"content": "Updated Content via PUT"}
+		jsonPayload, _ := json.Marshal(payload)
+		req, _ := http.NewRequest(http.MethodPut, "/articles/"+initialArticle.ID+"/content", bytes.NewBuffer(jsonPayload))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", status, http.StatusOK, rr.Body.String())
+		}
+		var respModel readmodels.ArticleReadModel
+		if err := json.NewDecoder(rr.Body).Decode(&respModel); err != nil {
+			t.Fatalf("Could not decode response: %v", err)
+		}
+		if respModel.Content != payload["content"] || respModel.Title != initialArticle.Title || respModel.Version != initialArticle.Version+1 {
+			t.Errorf("unexpected article state. Got: %+v", respModel)
+		}
+	})
+    
+    patchArticle := createArticleForTest(t, app, "Patch Original Title", "Patch Original Content")
+	t.Run("Success_PATCH", func(t *testing.T) {
+		payload := map[string]string{"content": "Updated Content via PATCH"}
+		jsonPayload, _ := json.Marshal(payload)
+		req, _ := http.NewRequest(http.MethodPatch, "/articles/"+patchArticle.ID+"/content", bytes.NewBuffer(jsonPayload))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", status, http.StatusOK, rr.Body.String())
+		}
+		var respModel readmodels.ArticleReadModel
+		if err := json.NewDecoder(rr.Body).Decode(&respModel); err != nil {
+			t.Fatalf("Could not decode response: %v", err)
+		}
+		if respModel.Content != payload["content"] || respModel.Title != patchArticle.Title || respModel.Version != patchArticle.Version+1 {
+			t.Errorf("unexpected article state. Got: %+v", respModel)
+		}
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		payload := map[string]string{"content": "Non Existent Content"}
+		jsonPayload, _ := json.Marshal(payload)
+		req, _ := http.NewRequest(http.MethodPut, "/articles/non-existent-id/content", bytes.NewBuffer(jsonPayload))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		if status := rr.Code; status != http.StatusNotFound {
+			t.Errorf("expected status %d, got %d", http.StatusNotFound, rr.Code)
+		}
+	})
+
+	badRequestTestCases := []struct{ name, payload, expectedErrorPart string }{
+		{"InvalidJSON", "{invalid", "Fehler beim Parsen"},
+		{"EmptyContent", `{"content":""}`, "Inhalt darf nicht leer sein"},
+		{"MissingContent", `{}`, "Inhalt darf nicht leer sein"},
+	}
+	for _, tc := range badRequestTestCases {
+		t.Run("BadRequest_"+tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodPut, "/articles/"+initialArticle.ID+"/content", bytes.NewBufferString(tc.payload))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+			if status := rr.Code; status != http.StatusBadRequest {
+				t.Errorf("expected status %d, got %d. Body: %s", http.StatusBadRequest, rr.Code, rr.Body.String())
+			}
+			if !strings.Contains(rr.Body.String(), tc.expectedErrorPart) {
+				t.Errorf("expected error message to contain '%s', got '%s'", tc.expectedErrorPart, rr.Body.String())
+			}
+		})
+	}
+}
+
+// --- Delete Article Tests ---
+func TestHandleDeleteArticle_Success(t *testing.T) {
+	app := setupTestApp()
+	router := setupTestRouter(app)
+	createdArticle := createArticleForTest(t, app, "To Be Deleted", "Delete Me")
+
+	req, _ := http.NewRequest("DELETE", "/articles/"+createdArticle.ID, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusNoContent {
+		t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", status, http.StatusNoContent, rr.Body.String())
+	}
+
+	// Verify it's gone
+	_, err := app.queryHandler.GetArticleByID(createdArticle.ID)
+	if err == nil {
+		t.Error("expected error when getting deleted article, but got nil")
+	}
+    expectedErrStr := fmt.Sprintf("artikel mit ID %s nicht gefunden", createdArticle.ID)
+    if err.Error() != expectedErrStr {
+        t.Errorf("expected error '%s' for deleted article, got '%s'", expectedErrStr, err.Error())
+    }
+}
+
+func TestHandleDeleteArticle_NotFound(t *testing.T) {
+	app := setupTestApp()
+	router := setupTestRouter(app)
+
+	req, _ := http.NewRequest("DELETE", "/articles/non-existent-id", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusNotFound {
+		t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", status, http.StatusNotFound, rr.Body.String())
+	}
+}
+
+// --- Test Method Not Allowed and Routing ---
+func TestRoutingAndMethodNotAllowed(t *testing.T) {
+    app := setupTestApp()
+    router := setupTestRouter(app)
+	existingArticle := createArticleForTest(t, app, "Test", "Test")
+
+
+    testCases := []struct {
+        method       string
+        path         string
+        expectedCode int
+    }{
+        // Collection endpoint
+        {http.MethodPut, "/articles", http.StatusMethodNotAllowed},
+        {http.MethodDelete, "/articles", http.StatusMethodNotAllowed},
+        {http.MethodPatch, "/articles", http.StatusMethodNotAllowed},
+
+        // Specific resource endpoint /articles/{id}
+        {http.MethodPost, "/articles/" + existingArticle.ID, http.StatusMethodNotAllowed},
+        {http.MethodPut, "/articles/" + existingArticle.ID, http.StatusMethodNotAllowed}, // No longer general PUT
+        {http.MethodPatch, "/articles/" + existingArticle.ID, http.StatusMethodNotAllowed},// No longer general PATCH
+
+        // Title sub-resource
+        {http.MethodGet, "/articles/" + existingArticle.ID + "/title", http.StatusNotFound}, // GET not defined for title
+        {http.MethodPost, "/articles/" + existingArticle.ID + "/title", http.StatusNotFound},// POST not defined for title
+		{http.MethodDelete, "/articles/" + existingArticle.ID + "/title", http.StatusNotFound},// DELETE not defined for title
+
+        // Content sub-resource
+        {http.MethodGet, "/articles/" + existingArticle.ID + "/content", http.StatusNotFound},
+        {http.MethodPost, "/articles/" + existingArticle.ID + "/content", http.StatusNotFound},
+		{http.MethodDelete, "/articles/" + existingArticle.ID + "/content", http.StatusNotFound},
+
+		// Invalid sub-resource
+		{http.MethodGet, "/articles/" + existingArticle.ID + "/invalid", http.StatusNotFound},
+		{http.MethodPut, "/articles/" + existingArticle.ID + "/invalid", http.StatusNotFound},
+
+    }
+
+    for _, tc := range testCases {
+        t.Run(tc.method+"_on_"+strings.ReplaceAll(tc.path, "/", "_"), func(t *testing.T) {
+            req, _ := http.NewRequest(tc.method, tc.path, nil)
+            rr := httptest.NewRecorder()
+            router.ServeHTTP(rr, req)
+            if status := rr.Code; status != tc.expectedCode {
+                t.Errorf("handler returned wrong status code: got %v want %v for %s %s. Body: %s",
+                    status, tc.expectedCode, tc.method, tc.path, rr.Body.String())
+            }
+        })
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module article-manager
+
+go 1.22.2
+
+require github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/article/aggregate_test.go
+++ b/internal/article/aggregate_test.go
@@ -1,0 +1,558 @@
+package article_test
+
+import (
+	"testing"
+	"time"
+	"errors" // For comparing error messages if needed
+
+	"article-manager/internal/article"
+	"article-manager/internal/events"
+
+	"github.com/google/uuid"
+)
+
+// Helper function to create a new UUID string for tests
+func newID() string {
+	return uuid.New().String()
+}
+
+func TestNewArticleAggregate(t *testing.T) {
+	id := newID()
+	agg := article.NewArticleAggregate(id)
+
+	if agg.ID != id {
+		t.Errorf("expected ID %s, got %s", id, agg.ID)
+	}
+	if agg.Version != -1 {
+		t.Errorf("expected Version -1, got %d", agg.Version)
+	}
+	if len(agg.GetChanges()) != 0 {
+		t.Errorf("expected 0 changes, got %d", len(agg.GetChanges()))
+	}
+}
+
+func TestArticleAggregate_HandleCreateArticleCommand(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		initialAggID := newID() // ID for NewArticleAggregate, will be overwritten by command
+		agg := article.NewArticleAggregate(initialAggID)
+		
+		articleID := newID()
+		title := "Test Title"
+		content := "Test Content"
+
+		err := agg.HandleCreateArticleCommand(articleID, title, content)
+		if err != nil {
+			t.Fatalf("HandleCreateArticleCommand failed: %v", err)
+		}
+
+		if agg.ID != articleID {
+			t.Errorf("expected aggregate ID %s, got %s", articleID, agg.ID)
+		}
+		if agg.Title != title {
+			t.Errorf("expected aggregate Title %s, got %s", title, agg.Title)
+		}
+		if agg.Content != content {
+			t.Errorf("expected aggregate Content %s, got %s", content, agg.Content)
+		}
+		if agg.Version != 0 {
+			t.Errorf("expected aggregate Version 0, got %d", agg.Version)
+		}
+
+		changes := agg.GetChanges()
+		if len(changes) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(changes))
+		}
+		event, ok := changes[0].(*events.ArticleCreatedEvent)
+		if !ok {
+			t.Fatalf("expected ArticleCreatedEvent, got %T", changes[0])
+		}
+		if event.ID != articleID {
+			t.Errorf("expected event ID %s, got %s", articleID, event.ID)
+		}
+		if event.Title != title {
+			t.Errorf("expected event Title %s, got %s", title, event.Title)
+		}
+		if event.Content != content {
+			t.Errorf("expected event Content %s, got %s", content, event.Content)
+		}
+		if event.Version != 0 { // Version in event should be 0
+			t.Errorf("expected event Version 0, got %d", event.Version)
+		}
+		if event.Timestamp.IsZero() {
+			t.Error("expected event Timestamp to be set")
+		}
+	})
+
+	t.Run("ValidationErrors", func(t *testing.T) {
+		testCases := []struct {
+			name    string
+			id      string
+			title   string
+			content string
+			wantErr error
+		}{
+			{"EmptyTitle", newID(), "", "Some Content", errors.New("Titel darf nicht leer sein")},
+			{"EmptyContent", newID(), "Some Title", "", errors.New("Inhalt darf nicht leer sein")},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				agg := article.NewArticleAggregate(newID())
+				err := agg.HandleCreateArticleCommand(tc.id, tc.title, tc.content)
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if err.Error() != tc.wantErr.Error() {
+					t.Errorf("expected error message '%s', got '%s'", tc.wantErr.Error(), err.Error())
+				}
+				if len(agg.GetChanges()) != 0 {
+					t.Errorf("expected 0 changes, got %d", len(agg.GetChanges()))
+				}
+			})
+		}
+	})
+}
+
+// Helper to create a base aggregate for update tests
+func setupAggregateForUpdateTests(t *testing.T) (*article.ArticleAggregate, string, string, string) {
+	t.Helper()
+	baseID := newID()
+	baseTitle := "Initial Title"
+	baseContent := "Initial Content"
+	agg := article.NewArticleAggregate(baseID)
+	err := agg.HandleCreateArticleCommand(baseID, baseTitle, baseContent)
+	if err != nil {
+		t.Fatalf("setup HandleCreateArticleCommand failed: %v", err)
+	}
+	agg.ClearChanges() // Clear create event changes before testing update
+	return agg, baseID, baseTitle, baseContent
+}
+
+
+func TestArticleAggregate_HandleUpdateArticleTitleCommand(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		agg, baseID, _, _ := setupAggregateForUpdateTests(t)
+		originalVersion := agg.Version // Should be 0
+
+		newTitle := "Updated Title Only"
+		err := agg.HandleUpdateArticleTitleCommand(newTitle)
+		if err != nil {
+			t.Fatalf("HandleUpdateArticleTitleCommand failed: %v", err)
+		}
+
+		if agg.Title != newTitle {
+			t.Errorf("expected Title %s, got %s", newTitle, agg.Title)
+		}
+		if agg.Version != originalVersion+1 {
+			t.Errorf("expected Version %d, got %d", originalVersion+1, agg.Version)
+		}
+
+		changes := agg.GetChanges()
+		if len(changes) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(changes))
+		}
+		event, ok := changes[0].(*events.ArticleTitleUpdatedEvent)
+		if !ok {
+			t.Fatalf("expected ArticleTitleUpdatedEvent, got %T", changes[0])
+		}
+		if event.ID != baseID {
+			t.Errorf("expected event ID %s, got %s", baseID, event.ID)
+		}
+		if event.NewTitle != newTitle {
+			t.Errorf("expected event NewTitle %s, got %s", newTitle, event.NewTitle)
+		}
+		if event.Version != agg.Version {
+			t.Errorf("expected event Version %d, got %d", agg.Version, event.Version)
+		}
+		if event.Timestamp.IsZero() {
+			t.Error("expected event Timestamp to be set")
+		}
+	})
+
+	t.Run("ValidationErrors", func(t *testing.T) {
+		testCases := []struct {
+			name    string
+			newTitle string
+			wantErr error
+			setup   func() *article.ArticleAggregate
+		}{
+			{"EmptyTitle", "", errors.New("Titel darf nicht leer sein"), func() *article.ArticleAggregate {
+				agg, _, _, _ := setupAggregateForUpdateTests(t); return agg
+			}},
+			{"SameTitle", "Initial Title", errors.New("Titel ist identisch, keine Änderung vorgenommen"), func() *article.ArticleAggregate {
+				agg, _, _, _ := setupAggregateForUpdateTests(t); return agg
+			}},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				agg := tc.setup()
+				err := agg.HandleUpdateArticleTitleCommand(tc.newTitle)
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if err.Error() != tc.wantErr.Error() {
+					t.Errorf("expected error message '%s', got '%s'", tc.wantErr.Error(), err.Error())
+				}
+				if len(agg.GetChanges()) != 0 {
+					t.Errorf("expected 0 changes after validation error, got %d", len(agg.GetChanges()))
+				}
+			})
+		}
+	})
+}
+
+func TestArticleAggregate_HandleUpdateArticleContentCommand(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		agg, baseID, _, _ := setupAggregateForUpdateTests(t)
+		originalVersion := agg.Version // Should be 0
+
+		newContent := "Updated Content Only"
+		err := agg.HandleUpdateArticleContentCommand(newContent)
+		if err != nil {
+			t.Fatalf("HandleUpdateArticleContentCommand failed: %v", err)
+		}
+
+		if agg.Content != newContent {
+			t.Errorf("expected Content %s, got %s", newContent, agg.Content)
+		}
+		if agg.Version != originalVersion+1 {
+			t.Errorf("expected Version %d, got %d", originalVersion+1, agg.Version)
+		}
+
+		changes := agg.GetChanges()
+		if len(changes) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(changes))
+		}
+		event, ok := changes[0].(*events.ArticleContentUpdatedEvent)
+		if !ok {
+			t.Fatalf("expected ArticleContentUpdatedEvent, got %T", changes[0])
+		}
+		if event.ID != baseID {
+			t.Errorf("expected event ID %s, got %s", baseID, event.ID)
+		}
+		if event.NewContent != newContent {
+			t.Errorf("expected event NewContent %s, got %s", newContent, event.NewContent)
+		}
+		if event.Version != agg.Version {
+			t.Errorf("expected event Version %d, got %d", agg.Version, event.Version)
+		}
+		if event.Timestamp.IsZero() {
+			t.Error("expected event Timestamp to be set")
+		}
+	})
+
+	t.Run("ValidationErrors", func(t *testing.T) {
+		testCases := []struct {
+			name    string
+			newContent string
+			wantErr error
+			setup   func() *article.ArticleAggregate
+		}{
+			{"EmptyContent", "", errors.New("Inhalt darf nicht leer sein"), func() *article.ArticleAggregate {
+				agg, _, _, _ := setupAggregateForUpdateTests(t); return agg
+			}},
+			{"SameContent", "Initial Content", errors.New("Inhalt ist identisch, keine Änderung vorgenommen"), func() *article.ArticleAggregate {
+				agg, _, _, _ := setupAggregateForUpdateTests(t); return agg
+			}},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				agg := tc.setup()
+				err := agg.HandleUpdateArticleContentCommand(tc.newContent)
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if err.Error() != tc.wantErr.Error() {
+					t.Errorf("expected error message '%s', got '%s'", tc.wantErr.Error(), err.Error())
+				}
+				if len(agg.GetChanges()) != 0 {
+					t.Errorf("expected 0 changes after validation error, got %d", len(agg.GetChanges()))
+				}
+			})
+		}
+	})
+}
+
+
+func TestArticleAggregate_HandleDeleteArticleCommand(t *testing.T) {
+	baseID := newID()
+	agg := article.NewArticleAggregate(baseID)
+	err := agg.HandleCreateArticleCommand(baseID, "Title to Delete", "Content to Delete")
+	if err != nil {
+		t.Fatalf("setup HandleCreateArticleCommand failed: %v", err)
+	}
+	agg.ClearChanges()
+	originalVersion := agg.Version // Should be 0
+
+	err = agg.HandleDeleteArticleCommand()
+	if err != nil {
+		t.Fatalf("HandleDeleteArticleCommand failed: %v", err)
+	}
+
+	// State changes for delete might be minimal (e.g., a 'deleted' flag if implemented)
+	// Here, we primarily check version and event.
+	if agg.Version != originalVersion+1 {
+		t.Errorf("expected Version %d, got %d", originalVersion+1, agg.Version)
+	}
+
+	changes := agg.GetChanges()
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(changes))
+	}
+	event, ok := changes[0].(*events.ArticleDeletedEvent)
+	if !ok {
+		t.Fatalf("expected ArticleDeletedEvent, got %T", changes[0])
+	}
+	if event.ID != baseID {
+		t.Errorf("expected event ID %s, got %s", baseID, event.ID)
+	}
+	if event.Version != agg.Version { // Version in event should match new aggregate version
+		t.Errorf("expected event Version %d, got %d", agg.Version, event.Version)
+	}
+	if event.Timestamp.IsZero() {
+		t.Error("expected event Timestamp to be set")
+	}
+}
+
+func TestArticleAggregate_ApplyEvent(t *testing.T) {
+	t.Run("ApplyArticleCreatedEvent", func(t *testing.T) {
+		agg := article.NewArticleAggregate(newID()) // Initial ID, will be overwritten by event
+		eventID := newID()
+		eventTitle := "Created Title"
+		eventContent := "Created Content"
+		eventVersion := 0 // Event carries version, but ApplyEvent itself shouldn't modify agg.Version
+
+		originalAggVersion := agg.Version // Should be -1
+
+		event := &events.ArticleCreatedEvent{
+			ID:        eventID,
+			Title:     eventTitle,
+			Content:   eventContent,
+			Timestamp: time.Now(),
+			Version:   eventVersion,
+		}
+		err := agg.ApplyEvent(event)
+		if err != nil {
+			t.Fatalf("ApplyEvent(ArticleCreatedEvent) failed: %v", err)
+		}
+
+		if agg.ID != eventID {
+			t.Errorf("expected ID %s, got %s", eventID, agg.ID)
+		}
+		if agg.Title != eventTitle {
+			t.Errorf("expected Title %s, got %s", eventTitle, agg.Title)
+		}
+		if agg.Content != eventContent {
+			t.Errorf("expected Content %s, got %s", eventContent, agg.Content)
+		}
+		// ApplyEvent itself does not change the aggregate's version.
+		// Command handlers are responsible for setting/incrementing the version.
+		if agg.Version != originalAggVersion {
+			t.Errorf("expected Version to remain %d after ApplyEvent, got %d", originalAggVersion, agg.Version)
+		}
+	})
+
+	t.Run("ApplyArticleTitleUpdatedEvent", func(t *testing.T) {
+		agg := article.NewArticleAggregate(newID())
+		agg.ApplyEvent(&events.ArticleCreatedEvent{ID: agg.ID, Title: "Old Title", Content: "Old Content", Version: 0})
+		originalAggVersion := agg.Version // Should be -1
+
+		updatedTitle := "Updated Title"
+		eventVersion := 1
+
+		event := &events.ArticleTitleUpdatedEvent{
+			ID:        agg.ID,
+			NewTitle:  updatedTitle,
+			Timestamp: time.Now(),
+			Version:   eventVersion,
+		}
+		err := agg.ApplyEvent(event)
+		if err != nil {
+			t.Fatalf("ApplyEvent(ArticleTitleUpdatedEvent) failed: %v", err)
+		}
+		if agg.Title != updatedTitle {
+			t.Errorf("expected Title %s, got %s", updatedTitle, agg.Title)
+		}
+		if agg.Version != originalAggVersion {
+			t.Errorf("expected Version to remain %d, got %d", originalAggVersion, agg.Version)
+		}
+	})
+
+	t.Run("ApplyArticleContentUpdatedEvent", func(t *testing.T) {
+		agg := article.NewArticleAggregate(newID())
+		agg.ApplyEvent(&events.ArticleCreatedEvent{ID: agg.ID, Title: "Old Title", Content: "Old Content", Version: 0})
+		originalAggVersion := agg.Version // Should be -1
+
+		updatedContent := "Updated Content"
+		eventVersion := 1
+
+		event := &events.ArticleContentUpdatedEvent{
+			ID:         agg.ID,
+			NewContent: updatedContent,
+			Timestamp:  time.Now(),
+			Version:    eventVersion,
+		}
+		err := agg.ApplyEvent(event)
+		if err != nil {
+			t.Fatalf("ApplyEvent(ArticleContentUpdatedEvent) failed: %v", err)
+		}
+		if agg.Content != updatedContent {
+			t.Errorf("expected Content %s, got %s", updatedContent, agg.Content)
+		}
+		if agg.Version != originalAggVersion {
+			t.Errorf("expected Version to remain %d, got %d", originalAggVersion, agg.Version)
+		}
+	})
+	
+	t.Run("ApplyArticleDeletedEvent", func(t *testing.T) {
+		agg := article.NewArticleAggregate(newID())
+		// Simulate existing state
+		agg.ApplyEvent(&events.ArticleCreatedEvent{ID: agg.ID, Title: "Title", Content: "Content", Version: 0})
+		originalAggVersion := agg.Version // Still -1
+
+		eventVersion := 1 // Event carries version
+
+		event := &events.ArticleDeletedEvent{
+			ID:        agg.ID,
+			Timestamp: time.Now(),
+			Version:   eventVersion,
+		}
+		err := agg.ApplyEvent(event)
+		if err != nil {
+			t.Fatalf("ApplyEvent(ArticleDeletedEvent) failed: %v", err)
+		}
+		// Verify any state changes if applicable (e.g., a 'deleted' flag)
+		// For now, just ensuring no error and version is not changed by ApplyEvent itself.
+		if agg.Version != originalAggVersion {
+			t.Errorf("expected Version to remain %d after ApplyEvent, got %d", originalAggVersion, agg.Version)
+		}
+	})
+
+	t.Run("UnknownEvent", func(t *testing.T) {
+		agg := article.NewArticleAggregate(newID())
+		err := agg.ApplyEvent("not an event type")
+		if err == nil {
+			t.Fatal("expected error for unknown event type, got nil")
+		}
+		expectedErr := errors.New("unbekanntes Event-Typ")
+		if err.Error() != expectedErr.Error() {
+			t.Errorf("expected error message '%s', got '%s'", expectedErr.Error(), err.Error())
+		}
+	})
+}
+
+func TestArticleAggregate_GetClearChanges(t *testing.T) {
+	agg := article.NewArticleAggregate(newID())
+	articleID := newID()
+	
+	// Record a change
+	err := agg.HandleCreateArticleCommand(articleID, "Test Title", "Test Content")
+	if err != nil {
+		t.Fatalf("HandleCreateArticleCommand failed: %v", err)
+	}
+
+	changes := agg.GetChanges()
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(changes))
+	}
+
+	agg.ClearChanges()
+	changes = agg.GetChanges()
+	if len(changes) != 0 {
+		t.Errorf("expected 0 changes after ClearChanges, got %d", len(changes))
+	}
+}
+
+func TestArticleAggregate_IncrementVersion(t *testing.T) {
+	agg := article.NewArticleAggregate(newID()) // Version is -1
+	
+	agg.IncrementVersion() // Version becomes 0
+	if agg.Version != 0 {
+		t.Errorf("expected Version 0 after first increment, got %d", agg.Version)
+	}
+
+	agg.IncrementVersion() // Version becomes 1
+	if agg.Version != 1 {
+		t.Errorf("expected Version 1 after second increment, got %d", agg.Version)
+	}
+}
+
+func TestArticleAggregate_HandleCreateArticleCommand_SetsEventVersionCorrectly(t *testing.T) {
+    agg := article.NewArticleAggregate(newID())
+    articleID := newID()
+    err := agg.HandleCreateArticleCommand(articleID, "Title", "Content")
+    if err != nil {
+        t.Fatalf("HandleCreateArticleCommand failed: %v", err)
+    }
+    // agg.Version is 0 after HandleCreateArticleCommand
+    changes := agg.GetChanges()
+    event, _ := changes[0].(*events.ArticleCreatedEvent)
+    if event.Version != 0 {
+        t.Errorf("expected event Version 0, got %d. Aggregate version is %d", event.Version, agg.Version)
+    }
+}
+
+func TestArticleAggregate_HandleUpdateArticleCommand_SetsEventVersionCorrectly(t *testing.T) {
+    agg := article.NewArticleAggregate(newID())
+    agg.HandleCreateArticleCommand(agg.ID, "Initial", "Initial") // Version becomes 0
+    agg.ClearChanges()
+
+    err := agg.HandleUpdateArticleTitleCommand("Updated Title") // Version becomes 1
+    if err != nil {
+        t.Fatalf("HandleUpdateArticleTitleCommand failed: %v", err)
+    }
+    changes := agg.GetChanges()
+    if len(changes) == 0 {
+        t.Fatalf("No events generated by HandleUpdateArticleTitleCommand")
+    }
+    event, ok := changes[0].(*events.ArticleTitleUpdatedEvent)
+    if !ok {
+        t.Fatalf("Expected ArticleTitleUpdatedEvent, got %T", changes[0])
+    }
+    if event.Version != 1 {
+        t.Errorf("expected event Version 1, got %d. Aggregate version is %d", event.Version, agg.Version)
+    }
+}
+
+
+func TestArticleAggregate_HandleUpdateArticleContentCommand_SetsEventVersionCorrectly(t *testing.T) {
+    agg := article.NewArticleAggregate(newID())
+    agg.HandleCreateArticleCommand(agg.ID, "Initial", "Initial") // Version becomes 0
+    agg.ClearChanges()
+
+    err := agg.HandleUpdateArticleContentCommand("Updated Content") // Version becomes 1
+    if err != nil {
+        t.Fatalf("HandleUpdateArticleContentCommand failed: %v", err)
+    }
+    changes := agg.GetChanges()
+    if len(changes) == 0 {
+        t.Fatalf("No events generated by HandleUpdateArticleContentCommand")
+    }
+    event, ok := changes[0].(*events.ArticleContentUpdatedEvent)
+     if !ok {
+        t.Fatalf("Expected ArticleContentUpdatedEvent, got %T", changes[0])
+    }
+    if event.Version != 1 {
+        t.Errorf("expected event Version 1, got %d. Aggregate version is %d", event.Version, agg.Version)
+    }
+}
+
+
+func TestArticleAggregate_HandleDeleteArticleCommand_SetsEventVersionCorrectly(t *testing.T) {
+    agg := article.NewArticleAggregate(newID())
+    agg.HandleCreateArticleCommand(agg.ID, "Initial", "Initial")
+    agg.ClearChanges() // Version is 0
+
+    err := agg.HandleDeleteArticleCommand()
+    if err != nil {
+        t.Fatalf("HandleDeleteArticleCommand failed: %v", err)
+    }
+    // agg.Version is 1 after HandleDeleteArticleCommand
+    changes := agg.GetChanges()
+    event, _ := changes[0].(*events.ArticleDeletedEvent)
+    if event.Version != 1 {
+        t.Errorf("expected event Version 1, got %d. Aggregate version is %d", event.Version, agg.Version)
+    }
+}

--- a/internal/article/article.go
+++ b/internal/article/article.go
@@ -1,0 +1,190 @@
+package article
+
+import (
+	"time" // Required for timestamps in events
+	"errors" // Required for error handling
+
+	"article-manager/internal/events" // Adjusted import path
+)
+
+// ArticleAggregate ist die Hauptentität für Artikel.
+// Es verwaltet den Zustand eines Artikels und die Geschäftslogik.
+type ArticleAggregate struct {
+	ID      string
+	Title   string
+	Content string
+	Version int
+	// ungespeicherte Änderungen/Events
+	changes []interface{}
+}
+
+// NewArticleAggregate erstellt eine neue Instanz eines ArticleAggregates.
+// Wird verwendet, wenn ein Aggregat aus dem Event-Stream neu erstellt wird.
+func NewArticleAggregate(id string) *ArticleAggregate {
+	return &ArticleAggregate{
+		ID:      id,
+		Version: -1, // Version initial auf -1 setzen
+		changes: make([]interface{}, 0),
+	}
+}
+
+// GetChanges gibt die nicht gespeicherten Änderungen zurück.
+func (a *ArticleAggregate) GetChanges() []interface{} {
+	return a.changes
+}
+
+// ClearChanges löscht die nicht gespeicherten Änderungen.
+func (a *ArticleAggregate) ClearChanges() {
+	a.changes = make([]interface{}, 0)
+}
+
+// IncrementVersion erhöht die Version des Aggregats.
+func (a *ArticleAggregate) IncrementVersion() {
+	a.Version++
+}
+
+// ApplyEvent wendet ein Event auf das Aggregat an, um dessen Zustand zu ändern.
+// Es wird aufgerufen, wenn das Aggregat aus dem Event Store geladen wird oder wenn ein neues Event erzeugt wird.
+func (a *ArticleAggregate) ApplyEvent(event interface{}) error {
+	switch e := event.(type) {
+	case *events.ArticleCreatedEvent:
+		a.ID = e.ID
+		a.Title = e.Title
+		a.Content = e.Content
+		// Die Version wird nicht mehr in ApplyEvent für ArticleCreatedEvent gesetzt.
+		// Der Aufrufer (HandleCreateArticleCommand oder loadAggregate) ist dafür verantwortlich.
+	case *events.ArticleTitleUpdatedEvent:
+		a.Title = e.NewTitle
+	case *events.ArticleContentUpdatedEvent:
+		a.Content = e.NewContent
+	case *events.ArticleDeletedEvent:
+		// Hier könnte man einen "gelöscht" Status setzen, falls Soft-Delete gewünscht ist.
+		// Für Hard-Delete ist hier eventuell keine Zustandsänderung nötig,
+		// aber das Event selbst signalisiert die Löschung.
+	default:
+		return errors.New("unbekanntes Event-Typ")
+	}
+	// Version wird beim Laden aus dem Store oder nach erfolgreichem Speichern extern gesetzt/inkrementiert.
+	// Hier direkt zu Inkrementieren beim Apply kann zu doppelter Zählung führen.
+	return nil
+}
+
+// recordChange fügt ein Event zu den ungespeicherten Änderungen hinzu.
+func (a *ArticleAggregate) recordChange(event interface{}) {
+	a.changes = append(a.changes, event)
+}
+
+// HandleCreateArticleCommand verarbeitet das CreateArticleCommand.
+// Es validiert das Command und erzeugt ein ArticleCreatedEvent.
+func (a *ArticleAggregate) HandleCreateArticleCommand(id string, title string, content string) error {
+	if title == "" {
+		return errors.New("Titel darf nicht leer sein")
+	}
+	if content == "" {
+		return errors.New("Inhalt darf nicht leer sein")
+	}
+
+	// a.Version ist hier -1. Nach ApplyEvent und dem Setzen wird es 0 sein.
+	// Das Event sollte die Version widerspiegeln, die das Aggregat *nach* diesem Event haben wird.
+	// Die Variable 'event' war hier deklariert, aber nicht mehr verwendet, nachdem 'createdEvent' eingeführt wurde.
+	// Sie wurde entfernt, um den "declared and not used" Fehler zu beheben.
+	// Erst ApplyEvent und Version setzen, dann die Version im Event festhalten.
+	// Die Logik unten setzt a.Version auf 0 NACH ApplyEvent.
+	// Das Event sollte die Version 0 tragen.
+	// Korrektur: Event muss nach der Versionsaktualisierung des Aggregats erstellt oder aktualisiert werden.
+	// Temporäre Variable für das Event, um die Version später zu setzen.
+	// Die erste, fehlerhafte a.recordChange(event) wurde entfernt.
+	createdEvent := &events.ArticleCreatedEvent{
+		ID:        id,
+		Title:     title,
+		Content:   content,
+		Timestamp: time.Now(),
+		// Version wird nach der Aktualisierung von a.Version gesetzt
+	}
+
+	if err := a.ApplyEvent(createdEvent); err != nil { // Zustand direkt anwenden und Fehler prüfen
+		return err
+	}
+	a.Version = 0 // Nach dem Erstellen ist die Version des Aggregats 0
+	createdEvent.Version = a.Version // Setze die korrekte Version im Event
+	a.recordChange(createdEvent) // Zeichne das Event mit der korrekten Version auf
+	return nil
+}
+
+// HandleUpdateArticleTitleCommand verarbeitet das UpdateArticleTitleCommand.
+// Es validiert das Command und erzeugt ein ArticleTitleUpdatedEvent.
+func (a *ArticleAggregate) HandleUpdateArticleTitleCommand(newTitle string) error {
+	if newTitle == "" {
+		return errors.New("Titel darf nicht leer sein")
+	}
+	if newTitle == a.Title {
+		return errors.New("Titel ist identisch, keine Änderung vorgenommen")
+	}
+
+	a.IncrementVersion() // Version erhöhen, bevor das Event erstellt wird
+
+	event := &events.ArticleTitleUpdatedEvent{
+		ID:        a.ID,
+		NewTitle:  newTitle,
+		Timestamp: time.Now(),
+		Version:   a.Version, // Die neue Version des Aggregats
+	}
+
+	// Zustand direkt anwenden
+	if err := a.ApplyEvent(event); err != nil {
+		a.Version-- // Version zurücksetzen, falls ApplyEvent fehlschlägt
+		return err
+	}
+	a.recordChange(event) // Event erst nach erfolgreicher Anwendung und Versionierung aufzeichnen
+	return nil
+}
+
+// HandleUpdateArticleContentCommand verarbeitet das UpdateArticleContentCommand.
+// Es validiert das Command und erzeugt ein ArticleContentUpdatedEvent.
+func (a *ArticleAggregate) HandleUpdateArticleContentCommand(newContent string) error {
+	if newContent == "" {
+		return errors.New("Inhalt darf nicht leer sein")
+	}
+	if newContent == a.Content {
+		return errors.New("Inhalt ist identisch, keine Änderung vorgenommen")
+	}
+
+	a.IncrementVersion() // Version erhöhen, bevor das Event erstellt wird
+
+	event := &events.ArticleContentUpdatedEvent{
+		ID:         a.ID,
+		NewContent: newContent,
+		Timestamp:  time.Now(),
+		Version:    a.Version, // Die neue Version des Aggregats
+	}
+	
+	// Zustand direkt anwenden
+	if err := a.ApplyEvent(event); err != nil {
+		a.Version-- // Version zurücksetzen, falls ApplyEvent fehlschlägt
+		return err
+	}
+	a.recordChange(event) // Event erst nach erfolgreicher Anwendung und Versionierung aufzeichnen
+	return nil
+}
+
+// HandleDeleteArticleCommand verarbeitet das DeleteArticleCommand.
+// Es erzeugt ein ArticleDeletedEvent.
+func (a *ArticleAggregate) HandleDeleteArticleCommand() error {
+	// Hier könnten Prüfungen stattfinden, z.B. ob der Artikel überhaupt existiert (hat eine Version > -1)
+	// oder ob er bereits gelöscht ist.
+
+	// Temporäre Variable für das Event, um die Version später zu setzen.
+	deletedEvent := &events.ArticleDeletedEvent{
+		ID:        a.ID,
+		Timestamp: time.Now(),
+		// Version wird nach der Aktualisierung von a.Version gesetzt
+	}
+
+	if err := a.ApplyEvent(deletedEvent); err != nil { // Zustand direkt anwenden und Fehler prüfen
+		return err
+	}
+	a.IncrementVersion() // Version erhöhen, nachdem das Event erfolgreich angewendet wurde
+	deletedEvent.Version = a.Version // Setze die korrekte Version im Event
+	a.recordChange(deletedEvent) // Zeichne das Event mit der korrekten Version auf
+	return nil
+}

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1,0 +1,25 @@
+package commands
+
+// CreateArticleCommand erstellt einen neuen Artikel.
+type CreateArticleCommand struct {
+	ID      string
+	Title   string
+	Content string
+}
+
+// UpdateArticleTitleCommand aktualisiert den Titel eines Artikels.
+type UpdateArticleTitleCommand struct {
+	ID    string
+	Title string
+}
+
+// UpdateArticleContentCommand aktualisiert den Inhalt eines Artikels.
+type UpdateArticleContentCommand struct {
+	ID      string
+	Content string
+}
+
+// DeleteArticleCommand löscht einen Artikel.
+type DeleteArticleCommand struct {
+	ID string
+}

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -1,0 +1,35 @@
+package events
+
+import "time"
+
+// ArticleCreatedEvent wird ausgelöst, wenn ein Artikel erstellt wurde.
+type ArticleCreatedEvent struct {
+	ID        string
+	Title     string
+	Content   string
+	Timestamp time.Time
+	Version   int
+}
+
+// ArticleTitleUpdatedEvent wird ausgelöst, wenn der Titel eines Artikels aktualisiert wurde.
+type ArticleTitleUpdatedEvent struct {
+	ID        string
+	NewTitle  string
+	Timestamp time.Time
+	Version   int
+}
+
+// ArticleContentUpdatedEvent wird ausgelöst, wenn der Inhalt eines Artikels aktualisiert wurde.
+type ArticleContentUpdatedEvent struct {
+	ID         string
+	NewContent string
+	Timestamp  time.Time
+	Version    int
+}
+
+// ArticleDeletedEvent wird ausgelöst, wenn ein Artikel gelöscht wurde.
+type ArticleDeletedEvent struct {
+	ID        string
+	Timestamp time.Time
+	Version   int
+}

--- a/internal/eventstore/eventstore.go
+++ b/internal/eventstore/eventstore.go
@@ -1,0 +1,76 @@
+package eventstore
+
+import (
+	"errors"
+	"sync"
+	// "article-manager/internal/events" // Not strictly needed for this basic implementation if we only store interface{}
+)
+
+// EventStore definiert die Schnittstelle für die Persistierung und das Abrufen von Events.
+type EventStore interface {
+	// SaveEvents speichert Events für ein bestimmtes Aggregat.
+	// Es erwartet die aggregateID, die Liste der Events und die erwartete Version des Aggregats (für Optimistic Locking).
+	SaveEvents(aggregateID string, events []interface{}, expectedVersion int) error
+	// GetEventsForAggregate ruft alle Events für ein bestimmtes Aggregat ab.
+	GetEventsForAggregate(aggregateID string) ([]interface{}, error)
+}
+
+// InMemoryEventStore ist eine einfache In-Memory-Implementierung des EventStore.
+// ACHTUNG: Nicht für den Produktionseinsatz geeignet, da die Daten bei Neustart verloren gehen.
+type InMemoryEventStore struct {
+	// mu schützt den Zugriff auf den events Speicher.
+	mu sync.RWMutex
+	// events speichert alle Events als Liste von Interfaces pro Aggregat-ID.
+	events map[string][]interface{}
+	// currentVersion speichert die aktuelle Version jedes Aggregats.
+	currentVersion map[string]int
+}
+
+// NewInMemoryEventStore erstellt einen neuen InMemoryEventStore.
+func NewInMemoryEventStore() *InMemoryEventStore {
+	return &InMemoryEventStore{
+		events:         make(map[string][]interface{}),
+		currentVersion: make(map[string]int),
+	}
+}
+
+// SaveEvents speichert die gegebenen Events.
+// Diese Implementierung prüft die erwartete Version für Optimistic Locking.
+func (s *InMemoryEventStore) SaveEvents(aggregateID string, newEvents []interface{}, expectedVersion int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	currentVersion, ok := s.currentVersion[aggregateID]
+	if !ok {
+		currentVersion = -1 // Aggregat existiert noch nicht, Version ist -1 (vor dem ersten Event)
+	}
+
+	if currentVersion != expectedVersion {
+		return errors.New("optimistic lock error: version mismatch")
+	}
+
+	s.events[aggregateID] = append(s.events[aggregateID], newEvents...)
+	s.currentVersion[aggregateID] = currentVersion + len(newEvents) // Die neue Version ist die alte Version plus die Anzahl der neuen Events
+
+	return nil
+}
+
+// GetEventsForAggregate ruft alle Events für eine gegebene Aggregat-ID ab.
+func (s *InMemoryEventStore) GetEventsForAggregate(aggregateID string) ([]interface{}, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	eventList, ok := s.events[aggregateID]
+	if !ok {
+		// Es ist kein Fehler, wenn für ein Aggregat keine Events vorhanden sind.
+		// Ein leeres Slice wird zurückgegeben.
+		return []interface{}{}, nil
+	}
+	// Eine Kopie zurückgeben, um externe Modifikationen der internen Slice zu verhindern,
+	// obwohl bei []interface{} die Elemente selbst noch Referenzen sein können.
+	// Für eine tiefere Kopie müsste man jedes Element einzeln kopieren.
+	// Für diesen Anwendungsfall ist eine flache Kopie der Slice ausreichend.
+	eventsToReturn := make([]interface{}, len(eventList))
+	copy(eventsToReturn, eventList)
+	return eventsToReturn, nil
+}

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1,0 +1,307 @@
+package handlers
+
+import (
+	"fmt"
+	"log" // Added for logging
+	"sync" // Added for ArticleEventHandler
+
+	"article-manager/internal/article"
+	"article-manager/internal/commands"
+	"article-manager/internal/eventstore"
+	"article-manager/internal/events"     // Added for ArticleEventHandler
+	"article-manager/internal/readmodels" // Added for ArticleEventHandler
+)
+
+// EventHandler defines the interface for handling events.
+// This allows for different implementations, including mocks for testing.
+type EventHandler interface {
+	HandleEvent(event interface{}) error
+}
+
+// ArticleCommandHandler verarbeitet Artikel-bezogene Commands.
+type ArticleCommandHandler struct {
+	eventStore   eventstore.EventStore
+	eventHandler EventHandler // Changed to interface type
+}
+
+// NewArticleCommandHandler erstellt einen neuen ArticleCommandHandler.
+func NewArticleCommandHandler(es eventstore.EventStore, eh EventHandler) *ArticleCommandHandler {
+	return &ArticleCommandHandler{
+		eventStore:   es,
+		eventHandler: eh, // Uses interface type
+	}
+}
+
+// HandleCreateArticle verarbeitet das CreateArticleCommand.
+// Es erstellt ein neues ArticleAggregate, führt das Command aus und speichert die resultierenden Events.
+func (h *ArticleCommandHandler) HandleCreateArticle(cmd commands.CreateArticleCommand) error {
+	expectedVersion := -1
+	aggregate := article.NewArticleAggregate(cmd.ID)
+
+	err := aggregate.HandleCreateArticleCommand(cmd.ID, cmd.Title, cmd.Content)
+	if err != nil {
+		return fmt.Errorf("fehler bei der Ausführung von CreateArticleCommand: %w", err)
+	}
+
+	changes := aggregate.GetChanges()
+	if len(changes) == 0 {
+		return fmt.Errorf("CreateArticleCommand erzeugte keine Events für Aggregat %s", cmd.ID)
+	}
+
+	err = h.eventStore.SaveEvents(aggregate.ID, changes, expectedVersion)
+	if err != nil {
+		return fmt.Errorf("fehler beim Speichern der Events für neues Aggregat %s (erwartete Version %d): %w", aggregate.ID, expectedVersion, err)
+	}
+
+	eventsToDispatch := aggregate.GetChanges()
+	for _, event := range eventsToDispatch {
+		if err := h.eventHandler.HandleEvent(event); err != nil {
+			log.Printf("FEHLER: Read-Model Event-Handler schlug fehl für Event %T Aggregat %s: %v", event, aggregate.ID, err)
+		}
+	}
+	aggregate.ClearChanges()
+	return nil
+}
+
+// HandleUpdateArticleTitle verarbeitet das UpdateArticleTitleCommand.
+func (h *ArticleCommandHandler) HandleUpdateArticleTitle(cmd commands.UpdateArticleTitleCommand) error {
+	aggregate, err := h.loadAggregate(cmd.ID)
+	if err != nil {
+		return fmt.Errorf("fehler beim Laden des Aggregats %s für HandleUpdateArticleTitle: %w", cmd.ID, err)
+	}
+
+	expectedVersion := aggregate.Version
+
+	err = aggregate.HandleUpdateArticleTitleCommand(cmd.Title)
+	if err != nil {
+		return fmt.Errorf("fehler bei der Ausführung von HandleUpdateArticleTitleCommand für Aggregat %s: %w", cmd.ID, err)
+	}
+
+	changes := aggregate.GetChanges()
+	if len(changes) == 0 {
+		log.Printf("WARNUNG: HandleUpdateArticleTitleCommand für Aggregat %s erzeugte keine Events, obwohl kein Fehler gemeldet wurde.", cmd.ID)
+		return nil
+	}
+
+	err = h.eventStore.SaveEvents(aggregate.ID, changes, expectedVersion)
+	if err != nil {
+		return fmt.Errorf("fehler beim Speichern der Events für Aggregat %s (erwartete Version %d) in HandleUpdateArticleTitle: %w", aggregate.ID, expectedVersion, err)
+	}
+
+	eventsToDispatch := aggregate.GetChanges()
+	for _, event := range eventsToDispatch {
+		if err := h.eventHandler.HandleEvent(event); err != nil {
+			log.Printf("FEHLER: Read-Model Event-Handler schlug fehl für Event %T Aggregat %s: %v", event, aggregate.ID, err)
+		}
+	}
+	aggregate.ClearChanges()
+	return nil
+}
+
+// HandleUpdateArticleContent verarbeitet das UpdateArticleContentCommand.
+func (h *ArticleCommandHandler) HandleUpdateArticleContent(cmd commands.UpdateArticleContentCommand) error {
+	aggregate, err := h.loadAggregate(cmd.ID)
+	if err != nil {
+		return fmt.Errorf("fehler beim Laden des Aggregats %s für HandleUpdateArticleContent: %w", cmd.ID, err)
+	}
+
+	expectedVersion := aggregate.Version
+
+	err = aggregate.HandleUpdateArticleContentCommand(cmd.Content)
+	if err != nil {
+		return fmt.Errorf("fehler bei der Ausführung von HandleUpdateArticleContentCommand für Aggregat %s: %w", cmd.ID, err)
+	}
+
+	changes := aggregate.GetChanges()
+	if len(changes) == 0 {
+		log.Printf("WARNUNG: HandleUpdateArticleContentCommand für Aggregat %s erzeugte keine Events, obwohl kein Fehler gemeldet wurde.", cmd.ID)
+		return nil
+	}
+
+	err = h.eventStore.SaveEvents(aggregate.ID, changes, expectedVersion)
+	if err != nil {
+		return fmt.Errorf("fehler beim Speichern der Events für Aggregat %s (erwartete Version %d) in HandleUpdateArticleContent: %w", aggregate.ID, expectedVersion, err)
+	}
+
+	eventsToDispatch := aggregate.GetChanges()
+	for _, event := range eventsToDispatch {
+		if err := h.eventHandler.HandleEvent(event); err != nil {
+			log.Printf("FEHLER: Read-Model Event-Handler schlug fehl für Event %T Aggregat %s: %v", event, aggregate.ID, err)
+		}
+	}
+	aggregate.ClearChanges()
+	return nil
+}
+
+// HandleDeleteArticle verarbeitet das DeleteArticleCommand.
+func (h *ArticleCommandHandler) HandleDeleteArticle(cmd commands.DeleteArticleCommand) error {
+	aggregate, err := h.loadAggregate(cmd.ID)
+	if err != nil {
+		return fmt.Errorf("fehler beim Laden des Aggregats %s für DeleteArticleCommand: %w", cmd.ID, err)
+	}
+
+	expectedVersion := aggregate.Version
+
+	err = aggregate.HandleDeleteArticleCommand()
+	if err != nil {
+		return fmt.Errorf("fehler bei der Ausführung von DeleteArticleCommand für Aggregat %s: %w", cmd.ID, err)
+	}
+
+	changes := aggregate.GetChanges()
+	if len(changes) == 0 {
+		return fmt.Errorf("DeleteArticleCommand erzeugte keine Events für Aggregat %s", cmd.ID)
+	}
+
+	err = h.eventStore.SaveEvents(aggregate.ID, changes, expectedVersion)
+	if err != nil {
+		return fmt.Errorf("fehler beim Speichern der Events für Aggregat %s (erwartete Version %d): %w", aggregate.ID, expectedVersion, err)
+	}
+
+	eventsToDispatch := aggregate.GetChanges()
+	for _, event := range eventsToDispatch {
+		if err := h.eventHandler.HandleEvent(event); err != nil {
+			log.Printf("FEHLER: Read-Model Event-Handler schlug fehl für Event %T Aggregat %s: %v", event, aggregate.ID, err)
+		}
+	}
+	aggregate.ClearChanges()
+	return nil
+}
+
+// loadAggregate lädt ein Aggregat aus dem EventStore.
+func (h *ArticleCommandHandler) loadAggregate(aggregateID string) (*article.ArticleAggregate, error) {
+	historicalEvents, err := h.eventStore.GetEventsForAggregate(aggregateID)
+	if err != nil {
+		return nil, fmt.Errorf("fehler beim Abrufen der Events für Aggregat %s: %w", aggregateID, err)
+	}
+
+	if len(historicalEvents) == 0 {
+		return nil, fmt.Errorf("aggregat %s nicht gefunden: keine Events vorhanden", aggregateID)
+	}
+
+	aggregate := article.NewArticleAggregate(aggregateID)
+	for _, event := range historicalEvents {
+		err = aggregate.ApplyEvent(event)
+		if err != nil {
+			return nil, fmt.Errorf("fehler beim Anwenden des Events auf Aggregat %s: %w", aggregateID, err)
+		}
+		aggregate.IncrementVersion()
+	}
+	return aggregate, nil
+}
+
+// -- Event Handler für Read Models --
+
+// ArticleEventHandler verarbeitet Events, um die ReadModels zu aktualisieren.
+type ArticleEventHandler struct {
+	mu       sync.RWMutex
+	articles map[string]readmodels.ArticleReadModel
+}
+
+// NewArticleEventHandler erstellt einen neuen ArticleEventHandler.
+func NewArticleEventHandler() *ArticleEventHandler {
+	return &ArticleEventHandler{
+		articles: make(map[string]readmodels.ArticleReadModel),
+	}
+}
+
+// HandleEvent verarbeitet ein einzelnes Event und aktualisiert das entsprechende ReadModel.
+func (h *ArticleEventHandler) HandleEvent(event interface{}) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	switch e := event.(type) {
+	case *events.ArticleCreatedEvent:
+		newArticle := readmodels.ArticleReadModel{
+			ID:      e.ID,
+			Title:   e.Title,
+			Content: e.Content,
+			Version: e.Version,
+		}
+		h.articles[e.ID] = newArticle
+		log.Printf("ReadModel für Artikel %s erstellt (Version %d): %+v", e.ID, e.Version, newArticle)
+
+	case *events.ArticleTitleUpdatedEvent:
+		currentArticle, ok := h.articles[e.ID]
+		if !ok {
+			log.Printf("WARNUNG: ArticleTitleUpdatedEvent für nicht existierendes ReadModel ID %s empfangen. Event ignoriert.", e.ID)
+			return nil
+		}
+		if e.Version > currentArticle.Version {
+			currentArticle.Title = e.NewTitle
+			currentArticle.Version = e.Version
+			h.articles[e.ID] = currentArticle
+			log.Printf("ReadModel Titel für Artikel %s aktualisiert (Version %d): %+v", e.ID, e.Version, currentArticle)
+		} else {
+			log.Printf("INFO: Veraltetes oder gleichwertiges ArticleTitleUpdatedEvent für ReadModel ID %s empfangen (EventVersion: %d, ReadModelVersion: %d). Ignoriert.", e.ID, e.Version, currentArticle.Version)
+		}
+
+	case *events.ArticleContentUpdatedEvent:
+		currentArticle, ok := h.articles[e.ID]
+		if !ok {
+			log.Printf("WARNUNG: ArticleContentUpdatedEvent für nicht existierendes ReadModel ID %s empfangen. Event ignoriert.", e.ID)
+			return nil
+		}
+		if e.Version > currentArticle.Version {
+			currentArticle.Content = e.NewContent
+			currentArticle.Version = e.Version
+			h.articles[e.ID] = currentArticle
+			log.Printf("ReadModel Inhalt für Artikel %s aktualisiert (Version %d): %+v", e.ID, e.Version, currentArticle)
+		} else {
+			log.Printf("INFO: Veraltetes oder gleichwertiges ArticleContentUpdatedEvent für ReadModel ID %s empfangen (EventVersion: %d, ReadModelVersion: %d). Ignoriert.", e.ID, e.Version, currentArticle.Version)
+		}
+
+	case *events.ArticleDeletedEvent:
+		if _, ok := h.articles[e.ID]; ok {
+			delete(h.articles, e.ID)
+			log.Printf("ReadModel für Artikel %s (Version %d) gelöscht.", e.ID, e.Version)
+		} else {
+			log.Printf("WARNUNG: ArticleDeletedEvent für nicht existierendes ReadModel ID %s empfangen (EventVersion: %d).", e.ID, e.Version)
+		}
+	
+	default:
+		log.Printf("Unbekanntes Event im ArticleEventHandler empfangen: %T", event)
+	}
+	return nil
+}
+
+// -- Query Handler für Read Models --
+
+// ArticleQueryHandler verarbeitet Abfragen zu Artikel-ReadModels.
+type ArticleQueryHandler struct {
+	eventHandler *ArticleEventHandler
+}
+
+// NewArticleQueryHandler erstellt einen neuen ArticleQueryHandler.
+func NewArticleQueryHandler(eventHandler *ArticleEventHandler) *ArticleQueryHandler {
+	return &ArticleQueryHandler{
+		eventHandler: eventHandler,
+	}
+}
+
+// GetArticleByID ruft ein Artikel-ReadModel anhand seiner ID ab.
+func (h *ArticleQueryHandler) GetArticleByID(id string) (readmodels.ArticleReadModel, error) {
+	h.eventHandler.mu.RLock()
+	defer h.eventHandler.mu.RUnlock()
+
+	article, ok := h.eventHandler.articles[id]
+	if !ok {
+		return readmodels.ArticleReadModel{}, fmt.Errorf("artikel mit ID %s nicht gefunden", id)
+	}
+	return article, nil
+}
+
+// GetAllArticles ruft alle Artikel-ReadModels ab.
+func (h *ArticleQueryHandler) GetAllArticles() ([]readmodels.ArticleReadModel, error) {
+	h.eventHandler.mu.RLock()
+	defer h.eventHandler.mu.RUnlock()
+
+	if len(h.eventHandler.articles) == 0 {
+		return []readmodels.ArticleReadModel{}, nil
+	}
+
+	articles := make([]readmodels.ArticleReadModel, 0, len(h.eventHandler.articles))
+	for _, article := range h.eventHandler.articles {
+		articles = append(articles, article)
+	}
+	return articles, nil
+}

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -1,0 +1,731 @@
+package handlers_test
+
+import (
+	"article-manager/internal/commands"
+	"article-manager/internal/events"
+	// "article-manager/internal/eventstore" // Interface is defined, but we use the mock
+	"article-manager/internal/handlers"
+	"errors"
+	"fmt"
+	"strings" // Added import
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Helper function to create a new UUID string for tests
+func newID() string {
+	return uuid.New().String()
+}
+
+// --- MockEventStore ---
+type MockEventStore struct {
+	SaveEventsFunc            func(aggregateID string, events []interface{}, expectedVersion int) error
+	GetEventsForAggregateFunc func(aggregateID string) ([]interface{}, error)
+
+	// Call recording fields
+	SavedAggID              string
+	SavedEvents             []interface{}
+	SavedExpectedVersion    int
+	GotAggIDForLoad         string
+	SaveEventsCalled        bool
+	GetEventsForAggCalled bool
+}
+
+func (m *MockEventStore) SaveEvents(aggregateID string, evts []interface{}, expectedVersion int) error {
+	m.SaveEventsCalled = true
+	m.SavedAggID = aggregateID
+	m.SavedEvents = evts
+	m.SavedExpectedVersion = expectedVersion
+	if m.SaveEventsFunc != nil {
+		return m.SaveEventsFunc(aggregateID, evts, expectedVersion)
+	}
+	return nil
+}
+
+func (m *MockEventStore) GetEventsForAggregate(aggregateID string) ([]interface{}, error) {
+	m.GetEventsForAggCalled = true
+	m.GotAggIDForLoad = aggregateID
+	if m.GetEventsForAggregateFunc != nil {
+		return m.GetEventsForAggregateFunc(aggregateID)
+	}
+	return []interface{}{}, nil
+}
+
+func (m *MockEventStore) Reset() {
+	m.SaveEventsCalled = false
+	m.GetEventsForAggCalled = false
+	m.SavedAggID = ""
+	m.SavedEvents = nil
+	m.SavedExpectedVersion = -2 // Use a value that's unlikely to be an actual expected version
+	m.GotAggIDForLoad = ""
+	m.SaveEventsFunc = nil
+	m.GetEventsForAggregateFunc = nil
+}
+
+// --- MockArticleEventHandler ---
+type MockArticleEventHandler struct {
+	HandleEventFunc func(event interface{}) error
+	HandledEvents   []interface{}
+	HandleEventCalled bool
+}
+
+func (m *MockArticleEventHandler) HandleEvent(event interface{}) error {
+	m.HandleEventCalled = true
+	m.HandledEvents = append(m.HandledEvents, event)
+	if m.HandleEventFunc != nil {
+		return m.HandleEventFunc(event)
+	}
+	return nil
+}
+
+func (m *MockArticleEventHandler) Reset() {
+	m.HandleEventCalled = false
+	m.HandledEvents = nil
+	m.HandleEventFunc = nil
+}
+
+
+// --- Test Suite ---
+
+func TestArticleCommandHandler_HandleCreateArticle(t *testing.T) {
+	mockES := &MockEventStore{}
+	mockEH := &MockArticleEventHandler{}
+	// Note: NewArticleCommandHandler now takes eventHandler as the second argument
+	cmdHandler := handlers.NewArticleCommandHandler(mockES, mockEH)
+
+	t.Run("Success", func(t *testing.T) {
+		mockES.Reset()
+		mockEH.Reset()
+
+		cmd := commands.CreateArticleCommand{
+			ID:      newID(),
+			Title:   "New Article",
+			Content: "Some content",
+		}
+
+		err := cmdHandler.HandleCreateArticle(cmd)
+		if err != nil {
+			t.Fatalf("HandleCreateArticle failed: %v", err)
+		}
+
+		if !mockES.SaveEventsCalled {
+			t.Error("expected EventStore.SaveEvents to be called")
+		}
+		if mockES.SavedAggID != cmd.ID {
+			t.Errorf("expected SavedAggID %s, got %s", cmd.ID, mockES.SavedAggID)
+		}
+		if len(mockES.SavedEvents) != 1 {
+			t.Fatalf("expected 1 saved event, got %d", len(mockES.SavedEvents))
+		}
+		createdEvent, ok := mockES.SavedEvents[0].(*events.ArticleCreatedEvent)
+		if !ok {
+			t.Fatalf("expected ArticleCreatedEvent, got %T", mockES.SavedEvents[0])
+		}
+		if createdEvent.ID != cmd.ID || createdEvent.Title != cmd.Title || createdEvent.Content != cmd.Content {
+			t.Errorf("event content mismatch. Expected ID %s, Title %s, Content %s. Got ID %s, Title %s, Content %s",
+				cmd.ID, cmd.Title, cmd.Content, createdEvent.ID, createdEvent.Title, createdEvent.Content)
+		}
+		if createdEvent.Version != 0 { // Version of the aggregate after creation
+			t.Errorf("expected createdEvent.Version to be 0, got %d", createdEvent.Version)
+		}
+		if mockES.SavedExpectedVersion != -1 {
+			t.Errorf("expected SavedExpectedVersion -1, got %d", mockES.SavedExpectedVersion)
+		}
+
+		if !mockEH.HandleEventCalled {
+			t.Error("expected EventHandler.HandleEvent to be called")
+		}
+		if len(mockEH.HandledEvents) != 1 {
+			t.Fatalf("expected 1 handled event, got %d", len(mockEH.HandledEvents))
+		}
+		if mockEH.HandledEvents[0] != createdEvent { // Should be the same event instance
+			t.Error("event handler handled a different event instance")
+		}
+	})
+
+	t.Run("SaveEventsError", func(t *testing.T) {
+		mockES.Reset()
+		mockEH.Reset()
+		expectedErr := errors.New("event store save failed")
+		mockES.SaveEventsFunc = func(aggregateID string, events []interface{}, expectedVersion int) error {
+			return expectedErr
+		}
+
+		cmd := commands.CreateArticleCommand{ID: newID(), Title: "Test", Content: "Test"}
+		err := cmdHandler.HandleCreateArticle(cmd)
+
+		if err == nil {
+			t.Fatal("expected an error from HandleCreateArticle, got nil")
+		}
+		if !errors.Is(err, expectedErr) && err.Error() != fmt.Errorf("fehler beim Speichern der Events für neues Aggregat %s (erwartete Version -1): %w", cmd.ID, expectedErr).Error() {
+            t.Errorf("expected error '%v', got '%v'", expectedErr, err)
+        }
+
+
+		if !mockES.SaveEventsCalled { // SaveEvents should still be called
+			t.Error("expected EventStore.SaveEvents to be called")
+		}
+		if mockEH.HandleEventCalled { // HandleEvent should NOT be called
+			t.Error("expected EventHandler.HandleEvent NOT to be called on SaveEvents error")
+		}
+	})
+
+	t.Run("EventHandlerError", func(t *testing.T) {
+		mockES.Reset()
+		mockEH.Reset()
+		eventHandlerErr := errors.New("event handler failed")
+		mockEH.HandleEventFunc = func(event interface{}) error {
+			return eventHandlerErr
+		}
+
+		cmd := commands.CreateArticleCommand{ID: newID(), Title: "Test", Content: "Test"}
+		err := cmdHandler.HandleCreateArticle(cmd)
+
+		if err != nil { // Command part is successful, so handler should not return error
+			t.Fatalf("HandleCreateArticle returned an error %v, expected nil (event handler error should be logged)", err)
+		}
+
+		if !mockES.SaveEventsCalled {
+			t.Error("expected EventStore.SaveEvents to be called")
+		}
+		if !mockEH.HandleEventCalled {
+			t.Error("expected EventHandler.HandleEvent to be called")
+		}
+		// Note: Testing log output is complex. We assume it's logged and the command completes.
+	})
+}
+
+func TestArticleCommandHandler_HandleUpdateArticleTitle(t *testing.T) {
+	mockES := &MockEventStore{}
+	mockEH := &MockArticleEventHandler{}
+	cmdHandler := handlers.NewArticleCommandHandler(mockES, mockEH)
+
+	articleID := newID()
+	initialCreateEvent := &events.ArticleCreatedEvent{
+		ID: articleID, Title: "Initial Title", Content: "Initial Content", Version: 0, Timestamp: time.Now(),
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		mockES.Reset()
+		mockEH.Reset()
+		mockES.GetEventsForAggregateFunc = func(id string) ([]interface{}, error) {
+			return []interface{}{initialCreateEvent}, nil
+		}
+
+		cmd := commands.UpdateArticleTitleCommand{ID: articleID, Title: "New Valid Title"}
+		err := cmdHandler.HandleUpdateArticleTitle(cmd)
+		if err != nil {
+			t.Fatalf("HandleUpdateArticleTitle failed: %v", err)
+		}
+
+		if !mockES.SaveEventsCalled {
+			t.Error("SaveEvents not called")
+		}
+		if mockES.SavedExpectedVersion != 0 {
+			t.Errorf("Expected version 0, got %d", mockES.SavedExpectedVersion)
+		}
+		if len(mockES.SavedEvents) != 1 {
+			t.Fatal("Expected 1 event")
+		}
+		evt, ok := mockES.SavedEvents[0].(*events.ArticleTitleUpdatedEvent)
+		if !ok {
+			t.Fatalf("Expected ArticleTitleUpdatedEvent, got %T", mockES.SavedEvents[0])
+		}
+		if evt.NewTitle != cmd.Title {
+			t.Errorf("Expected title '%s', got '%s'", cmd.Title, evt.NewTitle)
+		}
+		if evt.Version != 1 { // Version incremented from 0 to 1
+			t.Errorf("Expected event version 1, got %d", evt.Version)
+		}
+		if !mockEH.HandleEventCalled || len(mockEH.HandledEvents) != 1 || mockEH.HandledEvents[0] != evt {
+			t.Error("EventHandler not called correctly")
+		}
+	})
+
+	t.Run("AggregateNotFound", func(t *testing.T) {
+		mockES.Reset()
+		mockEH.Reset()
+		mockES.GetEventsForAggregateFunc = func(id string) ([]interface{}, error) {
+			return []interface{}{}, nil // No events means not found
+		}
+		cmd := commands.UpdateArticleTitleCommand{ID: articleID, Title: "New Title"}
+		err := cmdHandler.HandleUpdateArticleTitle(cmd)
+		if err == nil {
+			t.Fatal("Expected error for aggregate not found, got nil")
+		}
+		expectedErrStr := fmt.Sprintf("fehler beim Laden des Aggregats %s für HandleUpdateArticleTitle", articleID)
+		if !strings.Contains(err.Error(), expectedErrStr) {
+			t.Errorf("Expected error to contain '%s', got '%s'", expectedErrStr, err.Error())
+		}
+	})
+
+	t.Run("OptimisticLockErrorOnSave", func(t *testing.T) {
+		mockES.Reset()
+		mockEH.Reset()
+		mockES.GetEventsForAggregateFunc = func(id string) ([]interface{}, error) {
+			return []interface{}{initialCreateEvent}, nil
+		}
+		expectedErr := errors.New("optimistic lock error")
+		mockES.SaveEventsFunc = func(aggregateID string, evts []interface{}, expectedVersion int) error {
+			return expectedErr
+		}
+		cmd := commands.UpdateArticleTitleCommand{ID: articleID, Title: "New Title"}
+		err := cmdHandler.HandleUpdateArticleTitle(cmd)
+		if err == nil {
+			t.Fatal("Expected optimistic lock error, got nil")
+		}
+		expectedWrappedError := fmt.Sprintf("fehler beim Speichern der Events für Aggregat %s (erwartete Version 0) in HandleUpdateArticleTitle: %s", articleID, expectedErr.Error())
+		if err.Error() != expectedWrappedError {
+			t.Errorf("Expected error '%s', got '%s'", expectedWrappedError, err.Error())
+		}
+	})
+    
+    t.Run("AggregateReturnsError", func(t *testing.T) { // e.g. title is identical
+		mockES.Reset()
+		mockEH.Reset()
+		mockES.GetEventsForAggregateFunc = func(id string) ([]interface{}, error) {
+			return []interface{}{initialCreateEvent}, nil
+		}
+        // Command uses the same title as initialCreateEvent
+		cmd := commands.UpdateArticleTitleCommand{ID: articleID, Title: "Initial Title"} 
+		err := cmdHandler.HandleUpdateArticleTitle(cmd)
+		if err == nil {
+			t.Fatal("Expected error from aggregate (e.g. title identical), got nil")
+		}
+        expectedErrStr := "Titel ist identisch"
+        if !strings.Contains(err.Error(), expectedErrStr) {
+            t.Errorf("Expected error to contain '%s', got '%s'", expectedErrStr, err.Error())
+        }
+		if mockES.SaveEventsCalled {
+			t.Error("SaveEvents should not be called if aggregate returns error")
+		}
+	})
+}
+
+
+func TestArticleCommandHandler_HandleUpdateArticleContent(t *testing.T) {
+	mockES := &MockEventStore{}
+	mockEH := &MockArticleEventHandler{}
+	cmdHandler := handlers.NewArticleCommandHandler(mockES, mockEH)
+
+	articleID := newID()
+	initialCreateEvent := &events.ArticleCreatedEvent{
+		ID: articleID, Title: "Initial Title", Content: "Initial Content", Version: 0, Timestamp: time.Now(),
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		mockES.Reset()
+		mockEH.Reset()
+		mockES.GetEventsForAggregateFunc = func(id string) ([]interface{}, error) {
+			return []interface{}{initialCreateEvent}, nil
+		}
+
+		cmd := commands.UpdateArticleContentCommand{ID: articleID, Content: "New Valid Content"}
+		err := cmdHandler.HandleUpdateArticleContent(cmd)
+		if err != nil {
+			t.Fatalf("HandleUpdateArticleContent failed: %v", err)
+		}
+
+		if !mockES.SaveEventsCalled {
+			t.Error("SaveEvents not called")
+		}
+		if mockES.SavedExpectedVersion != 0 {
+			t.Errorf("Expected version 0, got %d", mockES.SavedExpectedVersion)
+		}
+		if len(mockES.SavedEvents) != 1 {
+			t.Fatal("Expected 1 event")
+		}
+		evt, ok := mockES.SavedEvents[0].(*events.ArticleContentUpdatedEvent)
+		if !ok {
+			t.Fatalf("Expected ArticleContentUpdatedEvent, got %T", mockES.SavedEvents[0])
+		}
+		if evt.NewContent != cmd.Content {
+			t.Errorf("Expected content '%s', got '%s'", cmd.Content, evt.NewContent)
+		}
+		if evt.Version != 1 { // Version incremented from 0 to 1
+			t.Errorf("Expected event version 1, got %d", evt.Version)
+		}
+		if !mockEH.HandleEventCalled || len(mockEH.HandledEvents) != 1 || mockEH.HandledEvents[0] != evt {
+			t.Error("EventHandler not called correctly")
+		}
+	})
+    // Add AggregateNotFound, OptimisticLockErrorOnSave, AggregateReturnsError (content identical)
+    // similar to HandleUpdateArticleTitle tests
+	t.Run("AggregateNotFound", func(t *testing.T) {
+		mockES.Reset()
+		mockEH.Reset()
+		mockES.GetEventsForAggregateFunc = func(id string) ([]interface{}, error) {
+			return []interface{}{}, nil // No events means not found
+		}
+		cmd := commands.UpdateArticleContentCommand{ID: articleID, Content: "New Content"}
+		err := cmdHandler.HandleUpdateArticleContent(cmd)
+		if err == nil {
+			t.Fatal("Expected error for aggregate not found, got nil")
+		}
+		expectedErrStr := fmt.Sprintf("fehler beim Laden des Aggregats %s für HandleUpdateArticleContent", articleID)
+		if !strings.Contains(err.Error(), expectedErrStr) {
+			t.Errorf("Expected error to contain '%s', got '%s'", expectedErrStr, err.Error())
+		}
+	})
+
+	t.Run("OptimisticLockErrorOnSave", func(t *testing.T) {
+		mockES.Reset()
+		mockEH.Reset()
+		mockES.GetEventsForAggregateFunc = func(id string) ([]interface{}, error) {
+			return []interface{}{initialCreateEvent}, nil
+		}
+		expectedErr := errors.New("optimistic lock error")
+		mockES.SaveEventsFunc = func(aggregateID string, evts []interface{}, expectedVersion int) error {
+			return expectedErr
+		}
+		cmd := commands.UpdateArticleContentCommand{ID: articleID, Content: "New Content"}
+		err := cmdHandler.HandleUpdateArticleContent(cmd)
+		if err == nil {
+			t.Fatal("Expected optimistic lock error, got nil")
+		}
+		expectedWrappedError := fmt.Sprintf("fehler beim Speichern der Events für Aggregat %s (erwartete Version 0) in HandleUpdateArticleContent: %s", articleID, expectedErr.Error())
+		if err.Error() != expectedWrappedError {
+			t.Errorf("Expected error '%s', got '%s'", expectedWrappedError, err.Error())
+		}
+	})
+    
+    t.Run("AggregateReturnsError", func(t *testing.T) { // e.g. content is identical
+		mockES.Reset()
+		mockEH.Reset()
+		mockES.GetEventsForAggregateFunc = func(id string) ([]interface{}, error) {
+			return []interface{}{initialCreateEvent}, nil
+		}
+        // Command uses the same content as initialCreateEvent
+		cmd := commands.UpdateArticleContentCommand{ID: articleID, Content: "Initial Content"} 
+		err := cmdHandler.HandleUpdateArticleContent(cmd)
+		if err == nil {
+			t.Fatal("Expected error from aggregate (e.g. content identical), got nil")
+		}
+        expectedErrStr := "Inhalt ist identisch"
+        if !strings.Contains(err.Error(), expectedErrStr) {
+            t.Errorf("Expected error to contain '%s', got '%s'", expectedErrStr, err.Error())
+        }
+		if mockES.SaveEventsCalled {
+			t.Error("SaveEvents should not be called if aggregate returns error")
+		}
+	})
+}
+
+
+func TestArticleCommandHandler_HandleDeleteArticle(t *testing.T) {
+	mockES := &MockEventStore{}
+	mockEH := &MockArticleEventHandler{}
+	cmdHandler := handlers.NewArticleCommandHandler(mockES, mockEH)
+
+	articleID := newID()
+	initialCreateEvent := &events.ArticleCreatedEvent{
+		ID: articleID, Title: "Initial Title", Content: "Initial Content", Version: 0, Timestamp: time.Now(),
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		mockES.Reset()
+		mockEH.Reset()
+
+		mockES.GetEventsForAggregateFunc = func(id string) ([]interface{}, error) {
+			if id != articleID {
+				t.Fatalf("GetEventsForAggregate called with wrong ID. Expected %s, got %s", articleID, id)
+			}
+			return []interface{}{initialCreateEvent}, nil
+		}
+
+		cmd := commands.DeleteArticleCommand{ID: articleID}
+		err := cmdHandler.HandleDeleteArticle(cmd)
+		if err != nil {
+			t.Fatalf("HandleDeleteArticle failed: %v", err)
+		}
+
+		if !mockES.GetEventsForAggCalled {
+			t.Error("expected EventStore.GetEventsForAggregate to be called")
+		}
+		if !mockES.SaveEventsCalled {
+			t.Error("expected EventStore.SaveEvents to be called")
+		}
+		if mockES.SavedAggID != articleID {
+			t.Errorf("expected SavedAggID %s, got %s", articleID, mockES.SavedAggID)
+		}
+		if len(mockES.SavedEvents) != 1 {
+			t.Fatalf("expected 1 saved event, got %d", len(mockES.SavedEvents))
+		}
+		deletedEvent, ok := mockES.SavedEvents[0].(*events.ArticleDeletedEvent)
+		if !ok {
+			t.Fatalf("expected ArticleDeletedEvent, got %T", mockES.SavedEvents[0])
+		}
+		if deletedEvent.ID != cmd.ID {
+			t.Errorf("event ID mismatch")
+		}
+		if deletedEvent.Version != 1 { // Version after delete (0 -> 1)
+			t.Errorf("expected deletedEvent.Version to be 1, got %d", deletedEvent.Version)
+		}
+		if mockES.SavedExpectedVersion != 0 { // Expected version was 0
+			t.Errorf("expected SavedExpectedVersion 0, got %d", mockES.SavedExpectedVersion)
+		}
+
+		if !mockEH.HandleEventCalled {
+			t.Error("expected EventHandler.HandleEvent to be called")
+		}
+		if len(mockEH.HandledEvents) != 1 {
+			t.Fatalf("expected 1 handled event, got %d", len(mockEH.HandledEvents))
+		}
+		if mockEH.HandledEvents[0] != deletedEvent {
+			t.Error("event handler handled a different event instance")
+		}
+	})
+	
+	// Similar tests for AggregateNotFound and OptimisticLockError can be added for Delete
+	// as they would follow the same pattern as HandleUpdateArticle.
+}
+
+
+// --- Helper functions for creating events ---
+func newArticleCreatedEventForTest(id, title, content string, version int) *events.ArticleCreatedEvent {
+	return &events.ArticleCreatedEvent{
+		ID:        id,
+		Title:     title,
+		Content:   content,
+		Timestamp: time.Now(),
+		Version:   version,
+	}
+}
+
+func newArticleTitleUpdatedEventForTest(id, title string, version int) *events.ArticleTitleUpdatedEvent {
+	return &events.ArticleTitleUpdatedEvent{
+		ID:        id,
+		NewTitle:  title,
+		Timestamp: time.Now(),
+		Version:   version,
+	}
+}
+
+func newArticleContentUpdatedEventForTest(id, content string, version int) *events.ArticleContentUpdatedEvent {
+	return &events.ArticleContentUpdatedEvent{
+		ID:         id,
+		NewContent: content,
+		Timestamp: time.Now(),
+		Version:   version,
+	}
+}
+
+func newArticleDeletedEventForTest(id string, version int) *events.ArticleDeletedEvent {
+	return &events.ArticleDeletedEvent{
+		ID:        id,
+		Timestamp: time.Now(),
+		Version:   version,
+	}
+}
+
+
+// --- Test Suite for ArticleEventHandler and ArticleQueryHandler (Integration) ---
+
+func TestArticleEventHandlerAndQueryHandler(t *testing.T) {
+	articleID1 := newID()
+	initialTitle1 := "Initial Title 1"
+	initialContent1 := "Initial Content 1"
+
+	articleID2 := newID()
+	initialTitle2 := "Initial Title 2"
+	initialContent2 := "Initial Content 2"
+
+
+	// These handlers will be re-initialized for some test groups for isolation
+	var eventHandler *handlers.ArticleEventHandler
+	var queryHandler *handlers.ArticleQueryHandler
+	
+	// Setup for tests that build state sequentially
+	setupSequential := func() {
+		eventHandler = handlers.NewArticleEventHandler()
+		queryHandler = handlers.NewArticleQueryHandler(eventHandler)
+	}
+
+
+	t.Run("EventHandler_ArticleCreated", func(t *testing.T) {
+		setupSequential() // Fresh handlers
+
+		createdEvent := newArticleCreatedEventForTest(articleID1, initialTitle1, initialContent1, 0)
+		err := eventHandler.HandleEvent(createdEvent)
+		if err != nil {
+			t.Fatalf("HandleEvent(created) failed: %v", err)
+		}
+
+		rm, err := queryHandler.GetArticleByID(articleID1)
+		if err != nil {
+			t.Fatalf("GetArticleByID after create failed: %v", err)
+		}
+		if rm.ID != articleID1 || rm.Title != initialTitle1 || rm.Content != initialContent1 || rm.Version != 0 {
+			t.Errorf("unexpected read model state after create: %+v", rm)
+		}
+	})
+
+	t.Run("EventHandler_ArticleTitleUpdated_Success", func(t *testing.T) {
+		setupSequential()
+		eventHandler.HandleEvent(newArticleCreatedEventForTest(articleID1, initialTitle1, initialContent1, 0))
+
+		updatedTitle := "Updated Title Only"
+		titleUpdatedEvent := newArticleTitleUpdatedEventForTest(articleID1, updatedTitle, 1)
+		err := eventHandler.HandleEvent(titleUpdatedEvent)
+		if err != nil {
+			t.Fatalf("HandleEvent(ArticleTitleUpdatedEvent) failed: %v", err)
+		}
+
+		rm, _ := queryHandler.GetArticleByID(articleID1)
+		if rm.Title != updatedTitle || rm.Version != 1 || rm.Content != initialContent1 {
+			t.Errorf("unexpected read model state after title update: %+v", rm)
+		}
+	})
+
+	t.Run("EventHandler_ArticleContentUpdated_Success", func(t *testing.T) {
+		setupSequential()
+		eventHandler.HandleEvent(newArticleCreatedEventForTest(articleID1, initialTitle1, initialContent1, 0))
+
+		updatedContent := "Updated Content Only"
+		contentUpdatedEvent := newArticleContentUpdatedEventForTest(articleID1, updatedContent, 1)
+		err := eventHandler.HandleEvent(contentUpdatedEvent)
+		if err != nil {
+			t.Fatalf("HandleEvent(ArticleContentUpdatedEvent) failed: %v", err)
+		}
+
+		rm, _ := queryHandler.GetArticleByID(articleID1)
+		if rm.Content != updatedContent || rm.Version != 1 || rm.Title != initialTitle1 {
+			t.Errorf("unexpected read model state after content update: %+v", rm)
+		}
+	})
+    
+    t.Run("EventHandler_ArticleTitleUpdated_StaleIgnored", func(t *testing.T) {
+		setupSequential()
+		eventHandler.HandleEvent(newArticleCreatedEventForTest(articleID1, initialTitle1, initialContent1, 0))
+		eventHandler.HandleEvent(newArticleTitleUpdatedEventForTest(articleID1, "New Title V1", 1)) // Version is 1
+
+		staleEvent := newArticleTitleUpdatedEventForTest(articleID1, "Stale Title V0", 0) // Stale version
+		eventHandler.HandleEvent(staleEvent)
+
+        rm, _ := queryHandler.GetArticleByID(articleID1)
+        if rm.Title != "New Title V1" || rm.Version != 1 {
+            t.Errorf("Stale title update was not ignored. ReadModel: %+v", rm)
+        }
+    })
+
+    t.Run("EventHandler_ArticleContentUpdated_StaleIgnored", func(t *testing.T) {
+		setupSequential()
+		eventHandler.HandleEvent(newArticleCreatedEventForTest(articleID1, initialTitle1, initialContent1, 0))
+		eventHandler.HandleEvent(newArticleContentUpdatedEventForTest(articleID1, "New Content V1", 1)) // Version is 1
+
+		staleEvent := newArticleContentUpdatedEventForTest(articleID1, "Stale Content V0", 0) // Stale version
+		eventHandler.HandleEvent(staleEvent)
+
+        rm, _ := queryHandler.GetArticleByID(articleID1)
+        if rm.Content != "New Content V1" || rm.Version != 1 {
+            t.Errorf("Stale content update was not ignored. ReadModel: %+v", rm)
+        }
+    })
+
+	t.Run("EventHandler_ArticleDeleted", func(t *testing.T) {
+		setupSequential()
+		// Create initial article
+		eventHandler.HandleEvent(newArticleCreatedEventForTest(articleID1, initialTitle1, initialContent1, 0))
+		// Optional: Update title once to ensure delete works on a modified article
+		eventHandler.HandleEvent(newArticleTitleUpdatedEventForTest(articleID1, "Before Delete", 1))
+
+
+		deletedEvent := newArticleDeletedEventForTest(articleID1, 2) // Version after delete is 2
+		err := eventHandler.HandleEvent(deletedEvent)
+		if err != nil {
+			t.Fatalf("HandleEvent(deleted) failed: %v", err)
+		}
+
+		_, err = queryHandler.GetArticleByID(articleID1)
+		if err == nil {
+			t.Errorf("expected error from GetArticleByID after delete, got nil")
+		}
+		expectedErrStr := fmt.Sprintf("artikel mit ID %s nicht gefunden", articleID1)
+		if err.Error() != expectedErrStr {
+			t.Errorf("expected error message '%s', got '%s'", expectedErrStr, err.Error())
+		}
+
+		allArticles, _ := queryHandler.GetAllArticles()
+		if len(allArticles) != 0 {
+			t.Errorf("expected 0 articles after delete, got %d", len(allArticles))
+		}
+	})
+
+	t.Run("EventHandler_UnknownEvent", func(t *testing.T) {
+		setupSequential()
+		// Create initial article
+		createdEvent := newArticleCreatedEventForTest(articleID1, initialTitle1, initialContent1, 0)
+		eventHandler.HandleEvent(createdEvent)
+
+		err := eventHandler.HandleEvent("this is not an event type string")
+		if err != nil {
+			t.Fatalf("HandleEvent(unknown) failed: %v", err) // Should log and ignore, not fail
+		}
+
+		rm, err := queryHandler.GetArticleByID(articleID1)
+		if err != nil {
+			t.Fatalf("GetArticleByID after unknown event failed: %v", err)
+		}
+		if rm.Title != initialTitle1 || rm.Content != initialContent1 || rm.Version != 0 {
+			t.Errorf("article state changed after unknown event. Got: %+v", rm)
+		}
+	})
+
+	t.Run("QueryHandler_GetArticleByID_NotFound", func(t *testing.T) {
+		setupSequential() // Fresh handlers, no articles
+
+		_, err := queryHandler.GetArticleByID("nonExistentID")
+		if err == nil {
+			t.Fatal("expected error for GetArticleByID nonExistentID, got nil")
+		}
+		expectedErrStr := "artikel mit ID nonExistentID nicht gefunden"
+		if err.Error() != expectedErrStr {
+			t.Errorf("expected error message '%s', got '%s'", expectedErrStr, err.Error())
+		}
+	})
+
+	t.Run("QueryHandler_GetAllArticles_Multiple", func(t *testing.T) {
+		setupSequential()
+
+		event1 := newArticleCreatedEventForTest(articleID1, initialTitle1, initialContent1, 0)
+		event2 := newArticleCreatedEventForTest(articleID2, initialTitle2, initialContent2, 0)
+		eventHandler.HandleEvent(event1)
+		eventHandler.HandleEvent(event2)
+
+		articles, err := queryHandler.GetAllArticles()
+		if err != nil {
+			t.Fatalf("GetAllArticles failed: %v", err)
+		}
+		if len(articles) != 2 {
+			t.Fatalf("expected 2 articles, got %d", len(articles))
+		}
+
+		// Check for presence of both articles (order is not guaranteed)
+		found1, found2 := false, false
+		for _, art := range articles {
+			if art.ID == articleID1 && art.Title == initialTitle1 {
+				found1 = true
+			}
+			if art.ID == articleID2 && art.Title == initialTitle2 {
+				found2 = true
+			}
+		}
+		if !found1 || !found2 {
+			t.Errorf("expected both articles to be present. Found1: %t, Found2: %t", found1, found2)
+		}
+	})
+
+	t.Run("QueryHandler_GetAllArticles_Empty", func(t *testing.T) {
+		setupSequential() // Fresh handlers
+
+		articles, err := queryHandler.GetAllArticles()
+		if err != nil {
+			t.Fatalf("GetAllArticles (empty) failed: %v", err)
+		}
+		if len(articles) != 0 {
+			t.Errorf("expected 0 articles for empty handler, got %d", len(articles))
+		}
+	})
+}

--- a/internal/readmodels/readmodels.go
+++ b/internal/readmodels/readmodels.go
@@ -1,0 +1,16 @@
+package readmodels
+
+// ArticleReadModel ist eine denormalisierte Repräsentation eines Artikels für Lesezugriffe.
+// Es wird durch Events aus dem System aktualisiert.
+type ArticleReadModel struct {
+	// ID ist die eindeutige Kennung des Artikels.
+	ID string
+	// Title ist der Titel des Artikels.
+	Title string
+	// Content ist der Inhalt des Artikels.
+	Content string
+	// Version gibt die Version des Aggregats an, auf der dieses ReadModel basiert.
+	// Dies hilft bei der Handhabung von out-of-order Events oder bei der Implementierung
+	// von Optimistic Locking auf der Lese-Seite, falls erforderlich.
+	Version int
+}


### PR DESCRIPTION
This refactoring introduces more specific updates for article attributes, replacing the general update functionality.

Changes include:

- API Endpoints:
  - Removed `PUT /articles/{id}`.
  - Added `PUT /articles/{id}/title` for updating only the title.
  - Added `PUT /articles/{id}/content` for updating only the content. (Supports PATCH method as well for these new endpoints).

- Commands:
  - Removed `UpdateArticleCommand`.
  - Added `UpdateArticleTitleCommand { ID, Title }`.
  - Added `UpdateArticleContentCommand { ID, Content }`.

- Events:
  - Removed `ArticleUpdatedEvent`.
  - Added `ArticleTitleUpdatedEvent { ID, NewTitle, Timestamp, Version }`.
  - Added `ArticleContentUpdatedEvent { ID, NewContent, Timestamp, Version }`.

- Domain (ArticleAggregate):
  - Removed `HandleUpdateArticleCommand`.
  - Added `HandleUpdateArticleTitleCommand` and `HandleUpdateArticleContentCommand`.
  - `ApplyEvent` updated to handle new granular events.

- Handlers:
  - `ArticleCommandHandler`: Updated to process new commands.
  - `ArticleEventHandler`: Updated to project new granular events to the read model.

- HTTP Layer (main.go):
  - Routing updated for new endpoints.
  - New HTTP handler functions for title and content updates.

- Testing:
  - All unit tests (aggregate, command handler, event handler, HTTP handlers) have been updated to reflect these changes and ensure correctness.
  - All tests are passing.